### PR TITLE
Prevent locale data corruption

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -167,7 +167,12 @@ function write(locale) {
     } catch(e) {
         fs.mkdirSync(directory, 0755);
     }
-    fs.writeFile(locate(locale), JSON.stringify(locales[locale], null, "\t"));
+    var target = locate(locale), tmp  = target + ".tmp";
+    fs.writeFile(tmp, JSON.stringify(locales[locale], null, "\t"),
+        "utf8", function(err) {
+            if(!err)
+                fs.renameSync(tmp, target);
+	});
 }
 
 // basic normalization of filepath


### PR DESCRIPTION
Hi,

thanks for creating this cool module!

During using it I noticed that the locale data is reinitialized when the application crashed. I use supervisor to restart my node app automatically when files change. This leads to application crashes like 

DEBUG: crashing child
DEBUG: Starting child process with 'node app.js'

quite often. Afterwards all my locale data was lost and a new locale file was created. After changing the write behaviour to create a temp file first and rename it then this issue did not occur any more.

I hope you find it useful.

Regards,
Patrick
