### PR TITLE
Made some improvements regarding query-string parameter and cookie

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -128,14 +128,17 @@ i18n.getLocale = function(request) {
     return request.locale;
 };
 
-i18n.overrideLocaleFromQuery = function(req) {
+i18n.overrideLocaleFromQuery = function(req, param) {
     if (req == null) {
         return;
     }
     var urlObj = url.parse(req.url, true);
+
+    param = param || 'locale';
+
     if (urlObj.query.locale) {
         if (debug) console.log("Overriding locale from query: " + urlObj.query.locale);
-        i18n.setLocale(req, urlObj.query.locale.toLowerCase());
+        i18n.setLocale(req, urlObj.query[param].toLowerCase());
     }
 }
 

--- a/i18n.js
+++ b/i18n.js
@@ -67,6 +67,14 @@ i18n.configure = function(opt) {
 i18n.init = function(request, response, next) {
     if (typeof request === 'object') {
         guessLanguage(request);
+
+        if (cookiename) {
+            if (response.cookie) {
+                response.cookie(cookiename, getLocale());
+            } else {
+                throw "Cookie parser not set.";
+            }
+        }
     }
     if (typeof next === 'function') {
         next();
@@ -124,6 +132,7 @@ i18n.setLocale = function(arg1, arg2) {
         request.locale = target_locale;
         defaultLocale = target_locale;
     }
+
     return i18n.getLocale(request);
 };
 

--- a/i18n.js
+++ b/i18n.js
@@ -134,9 +134,9 @@ i18n.overrideLocaleFromQuery = function(req, param) {
     }
     var urlObj = url.parse(req.url, true);
 
-    param = param || 'locale';
+    param = typeof param === 'string' ? param : 'locale';
 
-    if (urlObj.query.locale) {
+    if (urlObj.query[param]) {
         if (debug) console.log("Overriding locale from query: " + urlObj.query.locale);
         i18n.setLocale(req, urlObj.query[param].toLowerCase());
     }

--- a/i18n.js
+++ b/i18n.js
@@ -3,7 +3,7 @@
  * @link        https://github.com/mashpie/i18n-node
  * @license		http://creativecommons.org/licenses/by-sa/3.0/
  *
- * @version     0.3.4
+ * @version     0.3.5
  */
 
 // dependencies
@@ -24,7 +24,7 @@ var vsprintf = require('sprintf').vsprintf,
 // public exports
 var i18n = exports;
 
-i18n.version = '0.3.4';
+i18n.version = '0.3.5';
 
 i18n.configure = function(opt) {
     // you may register helpers in global scope, up to you
@@ -40,7 +40,7 @@ i18n.configure = function(opt) {
     }
 
     // query-string parameter to be watched
-    if (typeof opt.cookie === 'string') {
+    if (typeof opt.query_param === 'string') {
         query_param = opt.query_param;
     }
     

--- a/i18n.js
+++ b/i18n.js
@@ -156,7 +156,12 @@ function guessLanguage(request) {
         request.language = defaultLocale;
         request.region = defaultLocale;
 
-        if (language_header) {
+        // if a cookie is set, we've already guessed the language
+        if (cookiename && request.cookies[cookiename]) {
+            request.language = request.cookies[cookiename];
+        }
+        // otherwise, we should guess
+        else if (language_header) {
             language_header.split(',').forEach(function(l) {
                 header = l.split(';', 1)[0];
                 lr = header.split('-', 2);
@@ -177,11 +182,6 @@ function guessLanguage(request) {
                 request.regions = regions;
                 request.region = regions[0];
             }
-        }
-
-        // setting the language by cookie
-        if (cookiename && request.cookies[cookiename]) {
-            request.language = request.cookies[cookiename];
         }
 
         i18n.setLocale(request, request.language);


### PR DESCRIPTION
Here's a summary:

* Removed `overrideLocaleFromQuery()`, added to config options *query_param* and added to `guessLanguage()` query-string parameter detection (only if config *query_param* is set).
Comment: That way we don't have to call a method in case we want to detect locale from URL, which is pretty common. Just set the config parameter and we're good to go.

* Moved cookie detection in `guessLanguage()` to avoid useless detection from `Accept-Language` HTTP header.
Comment: If we have a cookie, why bother detecting the HTTP header?

* Made `init()` send the language cookie after guessing the language (only if config *cookiename* is set and CookieParser middleware is available).
Comment: if a cookie is set, the i18n already reads it to fetch the language. Instead of sending the cookie somewhere else in the app, `i18n.init()` now does it automatically which is pretty nice.

* Changed version to **0.3.5** as changes were significant.