### PR TITLE
Move express and vows from dependencies into devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lib": "."
   },
   "dependencies": {
-    "sprintf": ">=0.1.1",
+    "sprintf": ">=0.1.1"
+  },
+  "devDependencies": {
     "expresso": ">=0.9.2",
     "vows": ">=0.6.2"
   },


### PR DESCRIPTION
In package.json, for some users who cannot install expresso(e.g., window users without Make), I believe it is good idea to move some modules, which are not required in production mode, from dependencies into devDependencies.
