### PR TITLE
Russian-specific plurals support added.

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -99,11 +99,18 @@ i18n.__n = function () {
   var count = arguments[2];
   var msg = translate(locale, singular, plural);
 
-  if (parseInt(count, 10) > 1) {
-    msg = vsprintf(msg.other, [count]);
-  } else {
-    msg = vsprintf(msg.one, [count]);
-  }
+  var mod = Math.abs(parseInt(count, 10));
+  if (mod > 20) mod = mod % 10;
+
+  var form;
+
+  if (mod == 1) form = msg.one;
+  else if (mod > 1 && msg.other) form = msg.other;
+  else if (mod == 0 && msg.zero) form = msg.zero; 
+  else if (mod > 1 && mod < 5 && msg.two) form = msg.two;
+  else if (msg.five) form = msg.five;
+
+  msg = vsprintf(form, [count]);
 
   if (arguments.length > 3) {
     msg = vsprintf(msg, Array.prototype.slice.call(arguments, 3));

--- a/locales/ru.js
+++ b/locales/ru.js
@@ -1,0 +1,20 @@
+{
+  "Hello": "Привет",
+  "Hello %s, how are you today?": "Привет, %s, как дела?",
+  "weekend": "выходные",
+  "Hello %s, how are you today? How was your %s.": "Привет, %s, как дела? Как прошли %s?",
+  "Hi": "Трям",
+  "Howdy": "Чекак?",
+  "%s cat": {
+    "zero": "ни одной кошки",
+    "one": "%s кошка",
+    "two": "%s кошки",
+    "five": "%s кошек"
+  },
+  "There is one monkey in the %%s": {
+    "one": "На %%s сидит %d обезьянка",
+    "two": "На %%s сидят %d обезьянки",
+    "five" : "На %%s сидят %d обезьянок"
+  },
+  "tree": "дереве"
+}

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1,0 +1,20 @@
+{
+  "Hello": "Привет",
+  "Hello %s, how are you today?": "Привет, %s, как дела?",
+  "weekend": "выходные",
+  "Hello %s, how are you today? How was your %s.": "Привет, %s, как дела? Как прошли %s?",
+  "Hi": "Трям",
+  "Howdy": "Чекак?",
+  "%s cat": {
+    "zero": "ни одной кошки",
+    "one": "%s кошка",
+    "two": "%s кошки",
+    "five": "%s кошек"
+  },
+  "There is one monkey in the %%s": {
+    "one": "На %%s сидит %d обезьянка",
+    "two": "На %%s сидят %d обезьянки",
+    "five" : "На %%s сидят %d обезьянок"
+  },
+  "tree": "дереве"
+}

--- a/test/i18n.configure.js
+++ b/test/i18n.configure.js
@@ -4,7 +4,7 @@ var i18n = require('../i18n'),
     fs = require('fs');
 
 i18n.configure({
-  locales: ['en', 'de'],
+  locales: ['en', 'de', 'ru'],
   register: global,
   directory: './testlocales',
   extension: '.json',

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -4,7 +4,7 @@ var i18n = require('../i18n'),
 
 i18n.configure({
   // setup some locales - other locales default to en silently
-  locales: ['en', 'de'],
+  locales: ['en', 'de', 'ru'],
 
   // where to register __() and __n() to, might be "global" if you know what you are doing
   register: global
@@ -35,6 +35,11 @@ module.exports = {
     assert.equal(__('Hello %s, how are you today?', 'Marcus'), 'Hallo Marcus, wie geht es dir heute?');
     assert.equal(__('Hello %s, how are you today? How was your %s.', 'Marcus', __('weekend')), 'Hallo Marcus, wie geht es dir heute? Wie war dein Wochenende.');
 
+    i18n.setLocale('ru');
+    assert.equal(__('Hello'), 'Привет');
+    assert.equal(__('Hello %s, how are you today?', 'Marcus'), 'Привет, Marcus, как дела?');
+    assert.equal(__('Hello %s, how are you today? How was your %s.', 'Marcus', __('weekend')), 'Привет, Marcus, как дела? Как прошли выходные?');
+
   },
 
   'check plural': function () {
@@ -49,6 +54,21 @@ module.exports = {
     plural = __n('%s cat', '%s cats', 3);
     assert.equal(singular, '1 Katze');
     assert.equal(plural, '3 Katzen');
+
+    i18n.setLocale('ru');
+    var zero = __n('%s cat', '%s cats', 0);
+    singular = __n('%s cat', '%s cats', 1);
+    pluralTwo = __n('%s cat', '%s cats', 2);
+    pluralFive = __n('%s cat', '%s cats', 5);
+    pluralTwenty = __n('%s cat', '%s cats', 20);
+    pluralTwentyOne = __n('%s cat', '%s cats', 21);
+
+    assert.equal(zero, 'ни одной кошки');
+    assert.equal(singular, '1 кошка');
+    assert.equal(pluralTwo, '2 кошки');
+    assert.equal(pluralFive, '5 кошек');
+    assert.equal(pluralTwenty, '20 кошек');
+    assert.equal(pluralTwentyOne, '21 кошка');
   },
 
   'check nested plural': function () {
@@ -64,6 +84,13 @@ module.exports = {
     assert.equal(singular, 'Im Baum sitzt ein Affe');
     assert.equal(plural, 'Im Baum sitzen 3 Affen');
 
+    i18n.setLocale('ru');
+    singular = __n('There is one monkey in the %%s', 'There are %d monkeys in the %%s', 1, __('tree'));
+    plural = __n('There is one monkey in the %%s', 'There are %d monkeys in the %%s', 3, __('tree'));
+    zero = __n('There is one monkey in the %%s', 'There are %d monkeys in the %%s', 0, __('tree'));
+    assert.equal(singular, 'На дереве сидит 1 обезьянка');
+    assert.equal(plural, 'На дереве сидят 3 обезьянки');
+    assert.equal(zero, 'На дереве сидят 0 обезьянок');
   },
 
   'check variables': function () {


### PR DESCRIPTION
In Russian language there are several forms of plurals:
 - 1 cat - 1 кошка (form 'one' used)
 - 2,3 or 4 cats - 2, 3 или 4 кошки (form 'two' used)
 - 5-20 cats - 5-20 кошек (form 'five' used)
 - 21 cats - 21 кошка (again form of 'one' used)

... and so on.

Also, added 'zero' key for more human readable outputs for 0 case (like 'there are no monkeys in the tree').