### PR TITLE
Update README.md (missing next())

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ In an express app, you might use i18n.init to gather language settings of your v
 		  res.locals.__n = function() {
 		    return i18n.__n.apply(req, arguments);
 		  };
+		  // do not forget this, otherwise your app will hang
+		  next();
 		});
 
 	    app.use(app.router);


### PR DESCRIPTION
Missing next() instruction when binding helpers to the request
