### PR TITLE
Fallback to default locale if it couldn't be read

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -301,6 +301,12 @@ function translate(locale, singular, plural) {
 
   if (!locales[locale]) {
     read(locale);
+    if (!locales[locale]) {
+      if (debug) {
+        console.warn("WARN: Locale " + locale + " couldn't be read - check the context of the call to $__. Using " + defaultLocale + " (set by request) as current locale");
+      }
+      locale = defaultLocale;
+    }
   }
 
   if (plural) {


### PR DESCRIPTION
When translate() is called and the specified locale isn't loaded,
the locale will automatically be read() from disk.

If the locale file doesn't exist and updateFiles is true, then a new
locale will be created using write(). But if updateFiles is false (i.e. in production),
then write() won't do anything.

This means that we end up with locales[local] being undefined and
will crash right afterwards when indexing it.

This commit fixes that by checking if locales[local] is defined after
read() was called and switching to the default locale if it isn't.
