### PR TITLE
Remove the hard coded permissions of the `locales` directory

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -369,7 +369,7 @@ function write(locale) {
     stats = fs.lstatSync(directory);
   } catch (e) {
     logDebug('creating locales dir in: ' + directory);
-    fs.mkdirSync(directory, parseInt('755', 8));
+    fs.mkdirSync(directory);
   }
 
   // first time init has an empty file


### PR DESCRIPTION
When creating the `locales` directory, the mkdir call is made with hard coded permission settings 755. This is also the usual system default when manually creating a directory in the command line. That's because the default `umask` setting is the "equivalent" 0022.

However, having this hard coded, it becomes impossible to have `umask` set to 0002 to create directories with 775 permissions (rwx permissions for the group).

We need automated scripts that belong to the same group as our node user to be able to remove all the folders that are created by the node process. This includes this module's `locales` folder.

If there's no special reason to force permissions 755 for a newly created folder instead of relying on the default system `umask` settings, then it should be removed.