### PR TITLE
make i18n support region translation

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -293,6 +293,13 @@ function guessLanguage(request) {
       if (regions.length > 0) {
         request.regions = regions;
         request.region = regions[0];
+
+        // to test if having region translation
+        if (request.region && request.language && locales[ request.language + "-" + request.region]){
+          //logDebug("set region") ;
+          request.language = request.language + "-" + request.region;
+        }
+
       }
     }
 


### PR DESCRIPTION
This do overwrite the `request.language` value, but not change original behavior of `get` `set` `Locale`, could leave to developer decide want to support regional translation or not. 
