### PR TITLE
Custom storage backed and initialization

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -18,20 +18,13 @@ var vsprintf = require('sprintf').vsprintf,
     locales = {},
     api = ['__', '__n', 'getLocale', 'setLocale', 'getCatalog'],
     pathsep = path.sep || '/', // ---> means win support will be available in node 0.8.x and above
-    defaultLocale, updateFiles, cookiename, extension, directory, indent;
+    defaultLocale, updateFiles, cookiename, extension, directory, indent,
+    customReader;
 
 // public exports
 var i18n = exports;
 
 i18n.version = '0.4.1';
-
-i18n.loader = function (locale) {
-    if (typeof reader === 'function') {
-        reader(locale, locales);
-    } else {
-        read(locale);
-    }
-}
 
 i18n.configure = function i18nConfigure(opt) {
 
@@ -58,9 +51,9 @@ i18n.configure = function i18nConfigure(opt) {
   // setting defaultLocale
   defaultLocale = (typeof opt.defaultLocale === 'string') ? opt.defaultLocale : 'en';
   
-  // setting the locale reader function
-  reader = (typeof opt.reader === 'function') ? opt.reader : null;
-
+  // setting custom reader function
+  customReader = (typeof opt.reader === 'function') ? opt.reader : null;
+   
   // implicitly read all locales
   if (typeof opt.locales === 'object') {
     opt.locales.forEach(function (l) {
@@ -69,7 +62,7 @@ i18n.configure = function i18nConfigure(opt) {
   } 
   // execute function and pass the loader callback
   else if (typeof opt.locales === 'function') {
-      opt.locales(i18n.loader);
+      opt.locales(readerProxy);
   }
 };
 
@@ -543,6 +536,18 @@ function replacePlaceholders(msg, placeholders) {
     }
     
     return msg;
+}
+
+/**
+ * Reader proxy function. 
+ * Invokes a custom reader function if configured or reverts to the default one.
+ */
+function readerProxy (locale) {
+    if (typeof customReader === 'function') {
+        customReader(locale, locales);
+    } else {
+        read(locale);
+    }
 }
 
 /**

--- a/i18n.js
+++ b/i18n.js
@@ -57,7 +57,7 @@ i18n.configure = function i18nConfigure(opt) {
   // implicitly read all locales
   if (typeof opt.locales === 'object') {
     opt.locales.forEach(function (l) {
-      read(l);
+      readerProxy(l);
     });    
   } 
   // execute function and pass the loader callback


### PR DESCRIPTION
Hi,

no idea if anybody will find this interesting but here are some changes I implemented in order to enable loading from different sources then files. Our application stores all the translation messages as well as the list of supported locales in the database so I came up with this idea how to define custom storage backends without any hard dependencies to specific db drivers or ORMs.

the locales parameter can accept a closure with a callback parameter that is the actual locale that is being loaded.
then i added a reader parameter that recieves 2 parameters - one is the locale from the first function and the second param is the array of locales. 

the code bellow is my initialization using sequelize.js. 

``` node
i18n.configure({
    defaultLocale: 'en',
    updateFiles: false,
    locales: function (callback) {
        db.Intl.Locale.findAll().success(function (locales) {
            locales.forEach(function(locale) {
                callback(locale);                
            });
        });
    },
    reader: function(locale, result) {      
        result[locale.locale] = {};

        db.Intl.Error.findAll({where: {locale_id: locale.id}}).success(function (rows) {
            rows.forEach(function(row) {
                result[locale.locale][row.key] = row.message;                
            });
        });        
    }
});
```

another feature I have added is support for `%text%` style Symfony placeholders since we are sharing localization data between a Symfony 2 and node application.
This call handles the %id% placeholder in the text.

``` node
res.__('intl.locale.notfound', {id: req.params.id})
```

david
