### PR TITLE
Added a backup when reading invalid JSON files for locales, in order to prevent losing of translations because of syntax errors

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -436,6 +436,13 @@ function read(locale) {
     // unable to read, so intialize that file
     // locales[locale] are already set in memory, so no extra read required
     // or locales[locale] are empty, which initializes an empty locale.json file
+    
+    // since the current invalid locale could exist, we should back it up
+    if (fs.existsSync(file)) {
+      logDebug('backing up invalid locale ' + locale + ' to ' + file + '.invalid');
+      fs.renameSync(file, file + '.invalid');
+    }
+    
     logDebug('initializing ' + file);
     write(locale);
   }


### PR DESCRIPTION
I lost an entire translation file before being able to back it up, just because there was some syntax error on the JSON file.

I then felt an urge to fix this in a very simple way, by renaming the invalid locale file to locale.json.invalid, therefore preventing it from being lost forever.
