### PR TITLE
Provide a better usage api - i18n(options)

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -20,8 +20,25 @@ var vsprintf = require('sprintf').vsprintf,
     pathsep = path.sep || '/', // ---> means win support will be available in node 0.8.x and above
     defaultLocale, updateFiles, cookiename, extension, directory, indent;
 
-// public exports
-var i18n = exports;
+/**
+ * Basic configuration:
+ *
+ * 	i18n({
+ * 		locales:['en', 'de']
+ * 	})
+ *
+ * Use in express as a middleware:
+ *
+ *  app.use(i18n({
+ * 		locales:['en', 'de']
+ * 	}))
+ *
+ */
+
+var i18n = module.exports = function(options){
+	i18n.configure(options);
+	return i18n.init;
+};
 
 i18n.version = '0.4.1';
 

--- a/test/i18n.api.js
+++ b/test/i18n.api.js
@@ -4,7 +4,7 @@
 var i18n = process.env.EXPRESS_COV ? require('../i18n-cov') : require('../i18n'),
     should = require("should");
 
-i18n.configure({
+var middleware = i18n({
   locales: ['en', 'de'],
   directory: './locales',
   register: global
@@ -24,6 +24,7 @@ describe('Module Setup', function () {
   it('should export init as i18nInit', function () {
     should.equal(typeof i18n.init, 'function');
     should.equal(i18n.init.name, 'i18nInit');
+	should.equal(i18n.init, middleware);
   });
 
   it('should export __ as i18nTranslate', function () {


### PR DESCRIPTION
Basic configuration:

```
i18n({
    locales:['en', 'de']
})
```

 Use in express as a middleware:

```
app.use(i18n({
    locales:['en', 'de']
}))
```
