### PR TITLE
Conform Accept-Language header parsing to ICU standard

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -1,0 +1,41 @@
+{
+	"Hello": "Hello",
+	"Hello %s, how are you today?": "Hello %s, how are you today?",
+	"weekend": "weekend",
+	"Hello %s, how are you today? How was your %s.": "Hello %s, how are you today? How was your %s.",
+	"Hi": "Hi",
+	"Howdy": "Howdy",
+	"%s cat": {
+		"one": "%s cat",
+		"other": "%s cats"
+	},
+  "cat": {
+    "one": "%s cat",
+    "other": "%s cats"
+  },
+	"There is one monkey in the %%s": {
+		"one": "There is one monkey in the %%s",
+		"other": "There are %d monkeys in the %%s"
+	},
+	"tree": "tree",
+	"There is one monkey in the %s": {
+		"one": "There is one monkey in the %s",
+		"other": "There are %d monkeys in the %s"
+	},
+	"Hello %s": "Hello %s",
+	"Hello {{name}}": "Hello {{name}}",
+	"Hello {{name}}, how was your %s?": "Hello {{name}}, how was your %s?",
+	"format": {
+		"date": "DD/MM/YYYY",
+		"time": "h:mm:ss a"
+	},
+	"greeting": {
+		"formal": "Hello",
+		"informal": "Hi",
+		"placeholder": {
+			"formal": "Hello %s",
+			"informal": "Hi %s",
+			"loud": "greeting.placeholder.loud"
+		}
+	}
+}


### PR DESCRIPTION
Parsing the Accept-Language header to determine a user's preferred
language should follow the procedures established by ICU.  This
fixes both existing issues (e.g. changing case for languages like
en-GB) and allows more accurate language negotiation.
