### PR TITLE
use SVG to display Travis CI testing status and npm package's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stores language files in json files compatible to [webtranslateit](http://webtra
 Adds new strings on-the-fly when first used in your app.
 No extra parsing needed.
 
-[![Build Status](https://secure.travis-ci.org/mashpie/i18n-node.png?branch=master)](http://travis-ci.org/mashpie/i18n-node) [![NPM version](https://badge.fury.io/js/i18n.png)](http://badge.fury.io/js/i18n)
+[![Build Status](https://api.travis-ci.org/mashpie/i18n-node.svg?branch=master)](http://travis-ci.org/mashpie/i18n-node) [![NPM version](https://badge.fury.io/js/i18n.svg)](http://badge.fury.io/js/i18n)
 [![Dependency Status](https://gemnasium.com/mashpie/i18n-node.png)](https://gemnasium.com/mashpie/i18n-node)
 
 ## Install


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
