### PR TITLE
Support different delimiters with object notation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Combine those settings with you existing application if any of you other modules
 
 In addition to the traditional, linear translation lists, i18n also supports hierarchical translation catalogs.
 
-To enable this feature, be sure to set `objectNotation` to `true` in your `configure()` call.
+To enable this feature, be sure to set `objectNotation` to `true` in your `configure()` call. **Note**: If you can't or don't want to use `.` as a delimiter, set `objectNotation` to any other delimiter you like.
 
 Instead of calling `__("Hello")` you might call `__("greeting.formal")` to retrieve a formal greeting from a translation document like this one:
 

--- a/i18n.js
+++ b/i18n.js
@@ -54,7 +54,8 @@ i18n.configure = function i18nConfigure(opt) {
   defaultLocale = (typeof opt.defaultLocale === 'string') ? opt.defaultLocale : 'en';
 
   // enable object notation?
-  objectNotation = (typeof opt.objectNotation === 'boolean') ? opt.objectNotation : false;
+  objectNotation = (typeof opt.objectNotation !== 'undefined') ? opt.objectNotation : false;
+  if( objectNotation === true ) objectNotation = '.';
 
   // implicitly read all locales
   if (typeof opt.locales === 'object') {
@@ -489,7 +490,7 @@ function translate(locale, singular, plural) {
  */
 function localeAccessor(locale,singular,allowDelayedTraversal) {
   // Handle object lookup notation
-  var indexOfDot = singular.indexOf( '.' );
+  var indexOfDot = objectNotation && singular.indexOf( objectNotation );
   if( objectNotation && ( 0 < indexOfDot && indexOfDot < singular.length ) ) {
     // If delayed traversal wasn't specifically forbidden, it is allowed.
     if( typeof allowDelayedTraversal == "undefined" ) allowDelayedTraversal = true;
@@ -500,7 +501,7 @@ function localeAccessor(locale,singular,allowDelayedTraversal) {
     // Do we need to re-traverse the tree upon invocation of the accessor?
     var reTraverse = false;
     // Split the provided term and run the callback for each subterm.
-    singular.split( '.' ).reduce( function(object,index) {
+    singular.split( objectNotation ).reduce( function(object,index) {
       // Make the accessor return null.
       accessor = nullAccessor;
       // If our current target object (in the locale tree) doesn't exist or
@@ -550,7 +551,7 @@ function localeAccessor(locale,singular,allowDelayedTraversal) {
  */
 function localeMutator(locale,singular,allowBranching) {
   // Handle object lookup notation
-  var indexOfDot = singular.indexOf( '.' );
+  var indexOfDot = objectNotation && singular.indexOf( objectNotation );
   if( objectNotation && ( 0 < indexOfDot && indexOfDot < singular.length ) ) {
     // If branching wasn't specifically allowed, disable it.
     if( typeof allowBranching == "undefined" ) allowBranching = false;
@@ -561,7 +562,7 @@ function localeMutator(locale,singular,allowBranching) {
     // Are we going to need to re-traverse the tree when the mutator is invoked?
     var reTraverse = false;
     // Split the provided term and run the callback for each subterm.
-    singular.split( '.' ).reduce( function(object,index){
+    singular.split( objectNotation ).reduce( function(object,index){
       // Make the mutator do nothing.
       accessor = nullAccessor;
       // If our current target object (in the locale tree) doesn't exist or


### PR DESCRIPTION
Allows you to use strings other than `.` to delimit objects.

Very helpful when converting existing code bases to object notation, because you're likely to already use `.` in sentences in the translation documents. This way you can temporarily use a more unique token (like `///` or `→` and replace it again once all literals are converted to the new notation.
