### PR TITLE
Defend against various internal errors with object notation

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -489,6 +489,9 @@ function translate(locale, singular, plural) {
  * in the object at the requested location.
  */
 function localeAccessor(locale,singular,allowDelayedTraversal) {
+  // Bail out on non-existent locales to defend against internal errors.
+  if( !locales[locale] ) return Function.prototype;
+  
   // Handle object lookup notation
   var indexOfDot = objectNotation && singular.indexOf( objectNotation );
   if( objectNotation && ( 0 < indexOfDot && indexOfDot < singular.length ) ) {
@@ -550,6 +553,9 @@ function localeAccessor(locale,singular,allowDelayedTraversal) {
  * invoked, the targeted translation term will be set to the given value inside the locale table.
  */
 function localeMutator(locale,singular,allowBranching) {
+  // Bail out on non-existent locales to defend against internal errors.
+  if( !locales[locale] ) return Function.prototype;
+
   // Handle object lookup notation
   var indexOfDot = objectNotation && singular.indexOf( objectNotation );
   if( objectNotation && ( 0 < indexOfDot && indexOfDot < singular.length ) ) {


### PR DESCRIPTION
These changes simply allow us to bail out of the whole method when an inappropriate input is detected. Otherwise, the functions might cause errors like `Cannot call method 'hasOwnProperty' of undefined`.
The above case can happen when, for example, there's a syntax error in a locale .json file.

Returning a noop when the locale wasn't found, will ultimately result in the locale being written. So, if there was an error in the JSON file (trailing comma, string not closed, …), the whole file will be overwritten. Personally, I consider this a benefit, because it indicates to me that there was a problem with the locale file. If you have no copies of the file (in VCS or wherever), it would probably suck.

To prevent all of this happening, it might be wise to check `locales[locale]` after it was read (This is already happening, but the final read of `defaultLocale` is never checked). For reference: https://github.com/oliversalzburg/i18n-node/blob/0711eb7591c6b961cb1bc927ae1dcbf148b29752/i18n.js#L438
