### PR TITLE
Clear locales map on configure()

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -58,6 +58,7 @@ i18n.configure = function i18nConfigure(opt) {
   if( objectNotation === true ) objectNotation = '.';
 
   // implicitly read all locales
+  locales = {};
   if (typeof opt.locales === 'object') {
     opt.locales.forEach(function (l) {
       read(l);


### PR DESCRIPTION
Possible breaking change!

Currently, when calling `i18n.configure()`, the given `locales` will be *added* to the existing configuration, while the rest of the configuration will be *replaced*.

This can cause problems during testing (multiple `configure()` calls are probably rare in production).

Existing applications that might rely on this behavior, would no longer work.