### PR TITLE
Allow the user to define fallbacks for locales and languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Minimal example, just setup two locales and a project specific directory
 	    // setup some locales - other locales default to en silently
 	    locales:['en', 'de'],
 
+	    // fall back from Dutch to German
+	    fallbacks: {'nl':'de'},
+
 	    // you may alter a site wide default locale
 	    defaultLocale: 'de',
 

--- a/i18n.js
+++ b/i18n.js
@@ -61,6 +61,7 @@ i18n.configure = function i18nConfigure(opt) {
   fallbacks = (typeof opt.fallbacks === 'object') ? opt.fallbacks : null;
 
   // implicitly read all locales
+  locales = {};
   if (typeof opt.locales === 'object') {
     opt.locales.forEach(function (l) {
       read(l);

--- a/i18n.js
+++ b/i18n.js
@@ -356,20 +356,26 @@ function guessLanguage(request) {
         // Check if we have a configured fallback set for this language.
         if (fallbacks && fallbacks[lang]) {
           fallback = fallbacks[lang];
+          // Fallbacks for languages should be inserted where the original, unsupported language existed.
+          var acceptedLanguageIndex = accepted_languages.indexOf(lang);
           if(accepted_languages.indexOf(fallback) < 0) {
-            accepted_languages.push(fallback);
+            accepted_languages.splice(acceptedLanguageIndex + 1, 0, fallback);
           }
         }
 
         // Check if we have a configured fallback set for the parent language of the locale.
         if (fallbacks && fallbacks[parentLang]) {
           fallback = fallbacks[parentLang];
+          // Fallbacks for a parent language should be inserted to the end of the list, so they're only picked
+          // if there is no better match.
           if(accepted_languages.indexOf(fallback) < 0) {
             accepted_languages.push(fallback);
           }
         }
 
-        languages.push(parentLang.toLowerCase());
+        if (languages.indexOf(parentLang) < 0) {
+          languages.push(parentLang.toLowerCase());
+        }
         if (region) {
           regions.push(region.toLowerCase());
         }

--- a/i18n.js
+++ b/i18n.js
@@ -382,6 +382,7 @@ function guessLanguage(request) {
 
         if (!match && locales[lang]) {
           match = lang;
+          break;
         }
 
         if (!fallbackMatch && locales[parentLang]) {

--- a/test/i18n.fallbacks.js
+++ b/test/i18n.fallbacks.js
@@ -1,0 +1,137 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+// now with coverage suport
+var i18n = process.env.EXPRESS_COV ? require('../i18n-cov') : require('../i18n'),
+  should = require("should"),
+    path = require("path");
+
+describe('Fallbacks', function () {
+  var req = {
+    request: "GET /test",
+    __: i18n.__,
+    __n: i18n.__n,
+    locale: {},
+    headers: {}
+  };
+
+  describe('Fallback to language', function () {
+    beforeEach(function () {
+      // Force reloading of i18n, to reset configuration
+      var i18nPath = process.env.EXPRESS_COV ? 'i18n-cov' : 'i18n';
+      var i18nFilename = path.resolve(i18nPath + '.js');
+      delete require.cache[i18nFilename];
+      i18n = require( i18nFilename );
+
+      i18n.configure({
+        locales: ['en', 'de'],
+        defaultLocale: 'en',
+        fallbacks: {'foo': 'de', 'de-AT':'de'},
+        directory: './locales',
+        register: req
+      });
+      req.headers = {};
+      delete req.languages;
+      delete req.language;
+      delete req.locale;
+      delete req.region;
+      delete req.regions;
+    });
+
+    it('should fall back to "de" for language "foo"', function () {
+      req.headers['accept-language'] = 'foo';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de');
+    });
+    it('should fall back to "de" for language "foo-BAR"', function () {
+      req.headers['accept-language'] = 'foo-BAR';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de');
+    });
+    it('should fall back to "de" for locale "de-AT"', function () {
+      req.headers['accept-language'] = 'de-AT';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de');
+    });
+    it('should fall back to "de" for second-order locale "de-AT"', function () {
+      req.headers['accept-language'] = 'de-DK,de-AT';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de');
+    });
+    it('should use default "en" for valid locale request (ignoring fallbacks)', function () {
+      req.headers['accept-language'] = 'en-US,en,de-DK,de-AT';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('en');
+    });
+  });
+
+  describe('Fallback to locale', function () {
+    beforeEach(function () {
+      // Force reloading of i18n, to reset configuration
+      var i18nPath = process.env.EXPRESS_COV ? 'i18n-cov' : 'i18n';
+      var i18nFilename = path.resolve(i18nPath + '.js');
+      delete require.cache[i18nFilename];
+      i18n = require( i18nFilename );
+
+      i18n.configure({
+        locales: ['en-US', 'de-DE'],
+        defaultLocale: 'en-US',
+        fallbacks: {'de': 'de-DE'},
+        directory: './locales',
+        register: req
+      });
+      req.headers = {};
+      delete req.languages;
+      delete req.language;
+      delete req.locale;
+      delete req.region;
+      delete req.regions;
+    });
+
+    it('should fall back to "de-DE" for language "de-AT"', function () {
+      req.headers['accept-language'] = 'de-AT';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de-DE');
+    });
+    it('should fall back to "de-DE" for language "de"', function () {
+      req.headers['accept-language'] = 'de';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de-DE');
+    });
+  });
+
+  describe('Keep valid locale', function () {
+    beforeEach(function () {
+      // Force reloading of i18n, to reset configuration
+      var i18nPath = process.env.EXPRESS_COV ? 'i18n-cov' : 'i18n';
+      var i18nFilename = path.resolve(i18nPath + '.js');
+      delete require.cache[i18nFilename];
+      i18n = require( i18nFilename );
+
+      i18n.configure({
+        locales: ['de-AT', 'de-DE'],
+        defaultLocale: 'en-DE',
+        fallbacks: {'de': 'de-DE'},
+        directory: './locales',
+        register: global
+      });
+      req.headers = {};
+      delete req.languages;
+      delete req.language;
+      delete req.locale;
+      delete req.region;
+      delete req.regions;
+    });
+
+    it('should fall back to "de-DE" for language "de-SK"', function () {
+      req.headers['accept-language'] = 'de-SK';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de-DE');
+    });
+    it('should NOT fall back to "de-DE" for language "de-AT"', function () {
+      req.headers['accept-language'] = 'de-AT';
+      i18n.init(req);
+      i18n.getLocale(req).should.equal('de-AT');
+    });
+  });
+
+});


### PR DESCRIPTION
Using the `fallbacks` map in the options array, the user can define which locales or languages should be mapped to which locale or language.

As an example, we use this fallback system like so:

```js
i18n.configure( {
	locales        : [ "en-US", "de-DE" ],
	fallbacks      : { "en" : "en-US", "de" : "de-DE" },
	defaultLocale  : "en-US"
} );
```

This allows us to be explicit in our locale definition (using "de-DE" instead of "de"), but map other regions to the same language.

The current fallback mechanism in `guessLanguage` does not provide the same kind of functionality or flexibility.

Please note that the tests currently forcibly remove the i18n instance from the cache to allow proper recreation of the loaded locales. This would be fixed by #130 