### PR TITLE
Bumped version to 0.5.1

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -3,7 +3,7 @@
  * @link        https://github.com/mashpie/i18n-node
  * @license     http://opensource.org/licenses/MIT
  *
- * @version     0.4.1
+ * @version     0.5.1
  */
 
 // dependencies and "private" vars
@@ -23,7 +23,7 @@ var vsprintf = require('sprintf').vsprintf,
 // public exports
 var i18n = exports;
 
-i18n.version = '0.5.0';
+i18n.version = '0.5.1';
 
 i18n.configure = function i18nConfigure(opt) {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n",
   "description": "lightweight translation module with dynamic json storage",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "http://github.com/mashpie/i18n-node",
   "repository": {
     "type": "git",

--- a/test/i18n.api.js
+++ b/test/i18n.api.js
@@ -13,7 +13,7 @@ i18n.configure({
 
 describe('Module Setup', function () {
   it('should export a valid version', function () {
-    should.equal(i18n.version, '0.5.0');
+    should.equal(i18n.version, '0.5.1');
   });
 
   it('should export configure as i18nConfigure', function () {


### PR DESCRIPTION
I just thought it could be nice to have the git version higher than the one in npm.

Either way, the version in the header comment of `i18n.js` isn't correct.