### PR TITLE
Fix __n() with 2 arguments when using object notation

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -456,7 +456,7 @@ function translate(locale, singular, plural) {
       defaultSingular = singular.substring(indexOfColon + 1);
       singular = singular.substring(0, indexOfColon);
     }
-    if( plural ) {
+    if( plural && typeof plural !== 'number' ) {
       indexOfColon = plural.indexOf(':');
       if( 0 < indexOfColon ) {
         defaultPlural = plural.substring(indexOfColon + 1);

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,10 +9,18 @@
 		"one": "%s cat",
 		"other": "%s cats"
 	},
-  "cat": {
-    "one": "%s cat",
-    "other": "%s cats"
-  },
+	"cat": {
+		"one": "%s cat",
+		"other": "%s cats"
+	},
+	"nested": {
+		"deep": {
+			"plural": {
+				"one": "plural",
+				"other": "plurals"
+			}
+		}
+	},
 	"There is one monkey in the %%s": {
 		"one": "There is one monkey in the %%s",
 		"other": "There are %d monkeys in the %%s"
@@ -37,5 +45,9 @@
 			"informal": "Hi %s",
 			"loud": "greeting.placeholder.loud"
 		}
+	},
+	"nested.deep.plural": {
+		"one": "nested.deep.plural",
+		"other": 1
 	}
 }

--- a/test/i18n.api.js
+++ b/test/i18n.api.js
@@ -241,16 +241,11 @@ describe('Module API', function () {
         should.equal(plural, '3 Katzen');
       });
       
-      it('should allow two arguments and lookup strings in file', function(){
+      it('should allow two arguments', function(){
         var singular = __n("cat", 1);
         var plural = __n("cat", 3);
         should.equal(singular, '1 cat');
         should.equal(plural, '3 cats');
-        
-        singular = __n("nested.deep.plural", 1);
-        plural = __n("nested.deep.plural", 3);
-        should.equal(singular, 'plural');
-        should.equal(plural, 'plurals');
       });
     });
   });

--- a/test/i18n.api.js
+++ b/test/i18n.api.js
@@ -240,6 +240,18 @@ describe('Module API', function () {
         should.equal(singular, '1 Katze');
         should.equal(plural, '3 Katzen');
       });
+      
+      it('should allow two arguments and lookup strings in file', function(){
+        var singular = __n("cat", 1);
+        var plural = __n("cat", 3);
+        should.equal(singular, '1 cat');
+        should.equal(plural, '3 cats');
+        
+        singular = __n("nested.deep.plural", 1);
+        plural = __n("nested.deep.plural", 3);
+        should.equal(singular, 'plural');
+        should.equal(plural, 'plurals');
+      });
     });
   });
 

--- a/test/i18n.objectnotation.js
+++ b/test/i18n.objectnotation.js
@@ -48,6 +48,13 @@ describe('Object Notation', function () {
       should.equal(singular, '1 Katze');
       should.equal(plural, '3 Katzen');
     });
+    
+    it('should allow for simple pluralization', function(){
+      var singular = __n("nested.deep.plural", 1);
+      var plural = __n("nested.deep.plural", 3);
+      should.equal(singular, 'plural');
+      should.equal(plural, 'plurals');
+    });
   });
 
 


### PR DESCRIPTION
When I say "simple pluralization" I mean using `__n()` with only two arguments, such as `__n('cat', 1)`. `__n('cat', 1)` does work but an error is thrown when using object notation such as `__n('animals.cat', 1)`.

```
TypeError: Object 1 has no method 'indexOf'
      at translate (i18n.js:460:29)
      at i18nTranslatePlural (i18n.js:187:11)
      at object.(anonymous function) (i18n.js:332:29)
      at Context.<anonymous> (test/i18n.objectnotation.js:53:22)
```