### PR TITLE
Change sprintf module to a better supported implementation

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -7,7 +7,7 @@
  */
 
 // dependencies and "private" vars
-var vsprintf = require('sprintf').vsprintf,
+var vsprintf = require('sprintf-js').vsprintf,
     fs = require('fs'),
     url = require('url'),
     path = require('path'),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lib": "."
   },
   "dependencies": {
-    "sprintf": ">=0.1.1",
+    "sprintf-js": ">=1.0.3",
     "mustache": "*",
     "debug": "*"
   },


### PR DESCRIPTION
https://www.npmjs.com/package/sprintf states that “This package is not
maintained anymore.” and that you should move to
https://www.npmjs.com/package/sprintf-js
(https://github.com/alexei/sprintf.js)