### PR TITLE
update to express 4.x

### DIFF
--- a/examples/express-jade/express-jade.js
+++ b/examples/express-jade/express-jade.js
@@ -9,49 +9,48 @@
 
 // require modules
 var express = require('express'),
+    cookieParser = require('cookie-parser'),
     i18n = require('../../i18n'),
     url = require('url'),
-    jade = require('jade'),
-    app = module.exports = express();
+    app = express();
 
 // minimal config
 i18n.configure({
-  locales: ['en', 'fr'],
-  cookie: 'locale',
-  directory: __dirname + '/locales'
+    locales: ['en', 'fr'],
+    cookie: 'locale',
+    directory: __dirname + '/locales'
 });
 
-app.configure(function () {
-  // setup hbs
-  app.set('views', "" + __dirname + "/views");
-  app.set('view engine', 'jade');
+// setup hbs
+app.set('views', __dirname + "/views");
+app.set('view engine', 'jade');
 
-  // you'll need cookies
-  app.use(express.cookieParser());
+// you'll need cookies
+app.use(cookieParser());
 
-  // init i18n module for this loop
-  app.use(i18n.init);
-
-});
+// init i18n module for this loop
+app.use(i18n.init);
 
 // delay a response to simulate a long running process,
 // while another request comes in with altered language settings
 app.get('/', function (req, res) {
-  setTimeout(function () {
-    res.render('index');
-  }, app.getDelay(req, res));
+    setTimeout(function () {
+        res.render('index');
+    }, app.getDelay(req, res));
 });
 
 // set a cookie to requested locale
 app.get('/:locale', function (req, res) {
-  res.cookie('locale', req.params.locale);
-  res.redirect("/?delay=" + app.getDelay(req, res));
+    res.cookie('locale', req.params.locale);
+    res.redirect("/?delay=" + app.getDelay(req, res));
 });
 
 // simple param parsing
-app.getDelay = function (req, res) {
-  return url.parse(req.url, true).query.delay || 0;
+app.getDelay = function (req) {
+    return url.parse(req.url, true).query.delay || 0;
 };
 
 // startup
-app.listen(3000);
+app.listen(3000, function() {
+    console.log('The server is running on port %s', 3000);
+});

--- a/examples/express-jade/package.json
+++ b/examples/express-jade/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "express-jade",
+  "version": "1.0.0",
+  "description": "",
+  "main": "express-jade.js",
+  "scripts": {
+    "test": "node test.js",
+    "start": "node express-jade.js"
+  },
+  "author": "",
+  "private": true,
+  "dependencies": {
+    "cookie-parser": "^1.4.0",
+    "express": "^4.13.3"
+  }
+}

--- a/examples/express-jade/test.js
+++ b/examples/express-jade/test.js
@@ -6,7 +6,7 @@ var should = require('should'),
     browserEn = new Browser(),
     browserFr = new Browser();
 
-visitLinks = function (asyncMethod) {
+var visitLinks = function (asyncMethod) {
   return it('should show /en in English and /fr in French', function (done) {
     return async[asyncMethod]([
 
@@ -40,7 +40,7 @@ visitLinks = function (asyncMethod) {
   });
 };
 
-describe('Using i18n in express 3.x with jade template engine', function () {
+describe('Using i18n in express 4.x with jade template engine', function () {
   describe('non concurrent template rendering in different languages', function () {
     return visitLinks('series');
   });


### PR DESCRIPTION
Maybe it'd be a good idea to add an [editorconfig](http://editorconfig.org) to the main directory?
The main reason for this would be tabs vs 2 spaces vs 4 spaces.

I noticed there's no instructions on how the tests within each example are meant to be run, maybe add them to the package.json I added for the example? Currently running the test.js with `node test.js` produces this.
````
➜  express-jade git:(master) node test.js 
/Users/xo/code/i18n-node/node_modules/jsdom/lib/jsdom/level1/core.js:418
  set nodeName() { throw new core.DOMException();},
              ^^

SyntaxError: Setter must have exactly one formal parameter.
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:404:25)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Users/xo/code/i18n-node/node_modules/jsdom/lib/jsdom/level2/core.js:1:94)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
````