### PR TITLE
Some improvements and retryInDefaultLocale option

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -378,7 +378,17 @@ i18n.removeLocale = function i18nRemoveLocale(locale) {
 
 i18n._renderMustach = function renderMustach(msg, namedValues) {
   if (!Mustache) {
-    Mustache = require('mustache');
+    try {
+      Mustache = require('mustache');
+    } catch (error) {
+      if (error.code == 'MODULE_NOT_FOUND' || error.message.indexOf("Cannot find module") != -1) {
+        console.log("You need to run 'npm install mustache --save' in order to use mustache placeholders");
+        console.log(error.stack);
+        return msg;
+      } else {
+        throw error;
+      }
+    }
   }
   return Mustache.render(msg, namedValues);
 };

--- a/i18n.js
+++ b/i18n.js
@@ -379,6 +379,14 @@ i18n._renderMustach = function renderMustach(msg, namedValues) {
   return Mustache.render(msg, namedValues);
 };
 
+i18n.serializeLocale = function serializeLocal (localeObj) {
+  return JSON.stringify(localeObj, null, i18n.options.indent);
+};
+
+i18n.deserializeLocale = function serializeLocal (fileContent) {
+  return JSON.parse(fileContent);
+};
+
 // ===================
 // = private methods =
 // ===================
@@ -764,7 +772,7 @@ function read(locale) {
     localeFile = fs.readFileSync(file);
     try {
       // parsing filecontents to locales[locale]
-      locales[locale] = JSON.parse(localeFile);
+      locales[locale] = i18n.deserializeLocale(localeFile);
     } catch (parseError) {
       logError('unable to parse locales from file (maybe ' + file + ' is empty or invalid json?): ', parseError);
     }
@@ -813,7 +821,8 @@ function write(locale) {
   try {
     target = getStorageFilePath(locale);
     tmp = target + ".tmp";
-    fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, i18n.options.indent), "utf8");
+    var serialized = i18n.serializeLocale(locales[locale]);
+    fs.writeFileSync(tmp, serialized, "utf8");
     stats = fs.statSync(tmp);
     if (stats.isFile()) {
       fs.renameSync(tmp, target);

--- a/i18n.js
+++ b/i18n.js
@@ -7,6 +7,7 @@
  */
 
 // dependencies and "private" vars
+var Mustache;
 var vsprintf = require('sprintf-js').vsprintf,
   fs = require('fs'),
   url = require('url'),
@@ -14,7 +15,6 @@ var vsprintf = require('sprintf-js').vsprintf,
   debug = require('debug')('i18n:debug'),
   warn = require('debug')('i18n:warn'),
   error = require('debug')('i18n:error'),
-  Mustache = require('mustache'),
   locales = {},
   api = [
     '__',
@@ -184,7 +184,7 @@ i18n.__ = function i18nTranslate(phrase) {
 
   // if the msg string contains {{Mustache}} patterns we render it as a mini tempalate
   if ((/{{.*}}/).test(msg)) {
-    msg = Mustache.render(msg, namedValues);
+    msg = i18n._renderMustach(msg, namedValues);
   }
 
   // if we have extra arguments with values to get replaced,
@@ -252,7 +252,7 @@ i18n.__n = function i18nTranslatePlural(singular, plural, count) {
 
   // if the msg string contains {{Mustache}} patterns we render it as a mini tempalate
   if ((/{{.*}}/).test(msg)) {
-    msg = Mustache.render(msg, namedValues);
+    msg = i18n._renderMustach(msg, namedValues);
   }
 
   // if we have extra arguments with strings to get replaced,
@@ -367,6 +367,13 @@ i18n.addLocale = function i18nAddLocale(locale) {
 
 i18n.removeLocale = function i18nRemoveLocale(locale) {
   delete locales[locale];
+};
+
+i18n._renderMustach = function renderMustach(msg, namedValues) {
+  if (!Mustache) {
+    Mustache = require('mustache');
+  }
+  return Mustache.render(msg, namedValues);
 };
 
 // ===================

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "async": "*",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
+    "js-yaml": "^3.5.3",
     "jshint": "*",
     "mocha": "*",
+    "mustache": "*",
     "should": "*",
     "url": "^0.11.0",
-    "zombie": "*",
-    "mustache": "*"
+    "zombie": "*"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "debug": "*",
-    "mustache": "*",
     "sprintf-js": ">=1.0.3"
   },
   "devDependencies": {
@@ -30,7 +29,8 @@
     "mocha": "*",
     "should": "*",
     "url": "^0.11.0",
-    "zombie": "*"
+    "zombie": "*",
+    "mustache": "*"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/i18n.objectnotation.js
+++ b/test/i18n.objectnotation.js
@@ -57,5 +57,4 @@ describe('Object Notation', function () {
     });
   });
 
-
 });

--- a/test/i18n.retryInDefaultLocale.js
+++ b/test/i18n.retryInDefaultLocale.js
@@ -1,0 +1,73 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+// now with coverage suport
+var i18n = require('../i18n'),
+  should = require("should"),
+    path = require("path");
+
+describe('retryInDefaultLocale', function () {
+  beforeEach(function () {
+    i18n.removeLocale('nl');
+    i18n.configure({
+      locales: ['en', 'nl'],
+      directory: './locales',
+      register: global,
+      updateFiles: false,
+      objectNotation: true,
+      retryInDefaultLocale: true
+    });
+  });
+
+  describe('singular', function () {
+    var phrase = {phrase: 'greeting.formal', locale: 'nl'};
+
+    it('should return for return english translation', function () {
+      i18n.options.retryInDefaultLocale = false;
+      should.equal(i18n.__(phrase), 'greeting.formal');
+
+      // reload cache, becasue previous command already add new property
+      i18n.removeLocale('nl');
+
+      i18n.options.retryInDefaultLocale = true;
+      should.equal(i18n.__(phrase), 'Hello');
+    });
+
+    it('should work multple times (not set wrong cache)', function () {
+      for (var i = 0; i <= 5; i += 1) {
+        should.equal(i18n.__(phrase), 'Hello', "Fail on " + i + " interation");
+      }
+    });
+
+    it('should set cache to work fast', function () {
+      i18n.__(phrase);
+      should.equal(i18n.getCatalog('nl').greeting.formal, 'Hello');
+    });
+  });
+
+  describe('plural', function () {
+    var phrase = {singular: "cat", plural: "cat", locale: "nl"};
+
+    it('should return for plural', function () {
+      i18n.options.retryInDefaultLocale = false;
+      should.equal(i18n.__n(phrase, 3), 'cat');
+
+      // reload cache, becasue previous command already add new property
+      i18n.removeLocale('nl');
+
+      i18n.options.retryInDefaultLocale = true;
+      should.equal(i18n.__n(phrase, 3), '3 cats');
+    });
+
+    it('should work multple times (not set wrong cache)', function () {
+      for (var i = 0; i <= 5; i += 1) {
+        should.equal(i18n.__n(phrase, 3), '3 cats', "Fail on " + i + " interation");
+      }
+    });
+
+    it('should set cache to work fast', function () {
+      should.equal(i18n.__n(phrase, 3), '3 cats');
+      should.deepEqual(i18n.getCatalog('nl').cat, {one: "%s cat", other: "%s cats"});
+    });
+  });
+
+});

--- a/test/i18n.serialization.js
+++ b/test/i18n.serialization.js
@@ -1,0 +1,92 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+// now with coverage suport
+var i18n = require('../i18n'),
+  should = require("should"),
+    path = require("path"),
+      fs = require("fs"),
+    yaml = require("js-yaml");
+
+describe('retryInDefaultLocale', function () {
+  var testLocalesDir = './test/locales';
+  var locale_en = {
+    greeting: 'Hello',
+    approval: {
+      formal: "Well done",
+      informal: "Alright"
+    },
+    cats_count: {
+      one: "%s cat",
+      other: "%s cats"
+    }
+  };
+
+  beforeEach(function () {
+    // make sure there is no cache from previous tests
+    i18n.removeLocale('en');
+
+    i18n.serializeLocale = function (localeObj) {
+      return yaml.dump(localeObj);
+    };
+    i18n.deserializeLocale = function (fileContent) {
+      return yaml.load(fileContent);
+    };
+
+    if (!fs.existsSync(testLocalesDir)) {
+      fs.mkdirSync(testLocalesDir);
+    }
+    fs.writeFileSync(testLocalesDir + '/en.yml', i18n.serializeLocale(locale_en));
+
+    i18n.configure({
+      locales: ['en'],
+      directory: testLocalesDir,
+      extension: '.yml',
+      updateFiles: true,
+      objectNotation: true
+    });
+  });
+
+  afterEach(function () {
+    if (fs.existsSync(testLocalesDir)) {
+      fs.unlinkSync(testLocalesDir + '/en.yml');
+      fs.rmdirSync(testLocalesDir);
+    }
+  });
+
+  describe('parsing locale', function () {
+    it('should works for simple', function () {
+      should.equal(i18n.__('greeting'), "Hello");
+    });
+
+    it('should works for nested', function () {
+      should.equal(i18n.__('approval.formal'), "Well done");
+    });
+
+    it('should works for plural', function () {
+      should.equal(i18n.__n('cats_count', 1), "1 cat");
+      should.equal(i18n.__n('cats_count', 2), "2 cats");
+    });
+  });
+
+  describe('generating locale', function () {
+    it('should update locale on missing', function () {
+      i18n.__n('dogs_count:%s dog', 'dogs_count: %s dogs', 1);
+      var exptected = [
+        "greeting: Hello",
+        "approval:",
+        "  formal: Well done",
+        "  informal: Alright",
+        "cats_count:",
+        "  one: '%s cat'",
+        "  other: '%s cats'",
+        "dogs_count:",
+        "  one: '%s dog'",
+        "  other: ' %s dogs'\n"
+      ].join("\n");
+      should.equal(
+        fs.readFileSync(testLocalesDir + '/en.yml').toString(),
+        exptected
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Make Mustache as optional dependency

It will require `mustache` only if your key has `{{}}` in it, you can override rendering method via `i18n._renderMustach(msg, namedValues)`

Related: https://github.com/mashpie/i18n-node/pull/113
### Move all options in i18n.options, make it accessible from outside

I know some people like to keep things in private variables (What for? idk), but I hate when I need to fork library just to change some little thing inside. With this changes you can read/write options one by one.

``` js
// Example
i18n.options.defaultLocale // -> 'en'
i18n.options.fallbacks['ms'] = 'id'; 
i18n.options.fallbacks['uk'] = 'ru'; 
if (app.get('env') === 'production') {
  i18n.options.updateFiles = false;
}
```
### Expose API to override serialization:

I often put tailing coma in locale file and it gets revamped, with this I can set it in JS:
This feature will let you change format of locale file, it can be anything: yaml, js, properties, xml...

``` js
i18n.serializeLocale(localeObj)  // -> convert object to string
i18n.deserializeLocale(fileContent) // -> parse file content to object

// override deserializer to parse it as JS instead of JSON
i18n.deserializeLocale = function (fileContent) {
  return eval('var a = ' + fileContent + '; a');
};
```

Related: https://github.com/mashpie/i18n-node/pull/79 https://github.com/mashpie/i18n-node/pull/73
### Retry with `retryInDefaultLocale` option

With it's on, i18n will use default locale if can't find translation in current locale. I'm planing to use it in production. If I forget to add some translation - I prefer to see english words in production instead of `section.something.like.this`

``` js
i18n.configure({
  ...
  retryInDefaultLocale: true // default is false
});

// let's say english locale has this key, but user's locale don't
i18n.__('sidebar.promo.title') // -> "We have promo!!!"
```

P.S. I don't insist to merge it, but can be useful for other people
