### PR TITLE
Allow specification of alias methods for i18n API

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,17 @@ i18n.configure({
     // setting of log level ERROR - default to require('debug')('i18n:error')
     logErrorFn: function (msg) {
         console.log('error', msg);
-    }
+    },
 
     // object or [obj1, obj2] to bind the i18n api and current locale to - defaults to null
-    register: global
+    register: global,
+
+    // hash to specify different aliases for i18n's internal methods to apply on the request/response objects (method -> alias).
+    // note that this will *not* overwrite existing properties with the same name
+    api: {
+      '__': 't',  //now req.__ becomes req.t
+      '__n': 'tn' //and req.__n can be called as req.tn
+    }
 });
 ```
 
@@ -205,7 +212,7 @@ After this and until the cookie expires, `i18n.init()` will get the value of the
 
 #### Some words on `register` option
 
-Esp. when used in a cli like scriptyou won't use any `i18n.init()` to guess language settings from your user. Thus `i18n` won't bind itself to any `res` or `req` object and will work like a static module. 
+Esp. when used in a cli like scriptyou won't use any `i18n.init()` to guess language settings from your user. Thus `i18n` won't bind itself to any `res` or `req` object and will work like a static module.
 
 ```js
 var anyObject = {};
@@ -346,7 +353,7 @@ __n({singular: "%s cat", plural: "%s cats", locale: "fr", count: 3}); // 3 chat
 
 ### i18n.__l()
 
-Returns a list of translations for a given phrase in each language. 
+Returns a list of translations for a given phrase in each language.
 
 ```js
 i18n.__l('Hello'); // --> [ 'Hallo', 'Hello' ]
@@ -367,7 +374,7 @@ app.get( __l('/:locale/products/:id?'), function (req, res) {
 
 ### i18n.__h()
 
-Returns a hashed list of translations for a given phrase in each language. 
+Returns a hashed list of translations for a given phrase in each language.
 
 ```js
 i18n.__h('Hello'); // --> [ { de: 'Hallo' }, { en: 'Hello' } ]
@@ -731,9 +738,9 @@ __("greeting.placeholder.informal:Hi %s")
     * __improved__: `i18n.setLocale()` and `i18n.init()` refactored to comply with most common use cases, much better test coverage and docs
     * __new__: options: `autoReload`, `directoryPermissions`, `register`, `queryParameter`, read locales from filenames with empty `locales` option (#134)
     * __fixed__: typos, missing and wrong docs, issues related to `i18n.setLocale()`
-* 0.6.0: 
-    * __improved__: Accept-Language header parsing to ICU, delimiters with object notation, jshint, package.json, README; 
-    * __new__: prefix for locale files, `i18n.getLocales()`, custom logger, fallback[s]; 
+* 0.6.0:
+    * __improved__: Accept-Language header parsing to ICU, delimiters with object notation, jshint, package.json, README;
+    * __new__: prefix for locale files, `i18n.getLocales()`, custom logger, fallback[s];
     * __fixed__: typos, badges, plural (numbers), `i18n.setLocale()` for `req` _and_ `res`
 * 0.5.0: feature release; added {{mustache}} parsing by #85, added "object.notation" by #110, fixed buggy req.__() implementation by #111 and closed 13 issues
 * 0.4.1: stable release; merged/closed: #57, #60, #67 typo fixes; added more examples and new features: #53, #65, #66 - and some more api reference

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "url": "http://github.com/mashpie/i18n-node.git"
   },
   "author": "Marcus Spiegel <marcus.spiegel@gmail.com>",
+  "contributors": [{
+    "name": "Adam Buczynski",
+    "email": "me@adambuczynski.com",
+    "url": "http://adambuczynski.com/"
+  }],
   "main": "./index",
   "keywords": [
     "template",

--- a/test/i18n.configureApi.js
+++ b/test/i18n.configureApi.js
@@ -1,0 +1,71 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+var i18n = require('../i18n'),
+    should = require("should"),
+    fs = require('fs'),
+    path = require('path');
+
+var i18nPath = 'i18n';
+var i18nFilename = path.resolve(i18nPath + '.js');
+
+function reconfigure(config) {
+    delete require.cache[i18nFilename];
+    i18n = require(i18nFilename);
+    i18n.configure(config);
+}
+
+describe('configure api', function() {
+
+    it('should set an alias method on the object', function() {
+        var customObject = {};
+        reconfigure({
+            locales: ['en', 'de'],
+            register: customObject,
+            api: {
+              '__': 't'
+            }
+        });
+        should.equal(typeof customObject.t, 'function');
+        should.equal(customObject.t('Hello'), 'Hello');
+        customObject.setLocale('de');
+        should.equal(customObject.t('Hello'), 'Hallo');
+    });
+
+    it('should work for any existing API method', function() {
+        var customObject = {};
+        reconfigure({
+            locales: ['en', 'de'],
+            register: customObject,
+            api: {
+              'getLocale': 'getLocaleAlias'
+            }
+        });
+        should.equal(typeof customObject.getLocaleAlias, 'function');
+        customObject.setLocale('de');
+        should.equal(customObject.getLocaleAlias(), 'de');
+    });
+
+    it('should ignore non existing API methods', function() {
+        var customObject = {};
+        reconfigure({
+            locales: ['en', 'de'],
+            register: customObject,
+            api: {
+              'nonExistingMethod': 'alias'
+            }
+        });
+        should.equal(typeof customObject.nonExistingMethod, 'undefined');
+    });
+
+    it('should not expose the actual API methods', function() {
+        var customObject = {};
+        reconfigure({
+            locales: ['en', 'de'],
+            register: customObject,
+            api: {
+              '__': 't'
+            }
+        });
+        should.equal(typeof customObject.__, 'undefined');
+    });
+});


### PR DESCRIPTION
Allow specification of alias methods for i18n API. I have added:

- A new configuration parameter `api`
- Readme documentation for its usage
- Tests

This PR changes the internal `api` array into an object hash with method -> alias mapping. 

Fully backwards compatible.

Closes #154