### PR TITLE
setCatalog - allow your app to write updated translations back to file

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -37,6 +37,7 @@ module.exports = (function() {
       '__mf': '__mf',
       'getLocale': 'getLocale',
       'setLocale': 'setLocale',
+      'setCatalog': 'setCatalog',
       'getCatalog': 'getCatalog',
       'getLocales': 'getLocales',
       'addLocale': 'addLocale',
@@ -456,6 +457,11 @@ module.exports = (function() {
     return this.locale || defaultLocale;
   };
 
+  // Write back to the catalog with updated translations.
+  i18n.setCatalog = function i18nSetCatalog(locale) {
+    write(locale);
+  };
+  
   i18n.getCatalog = function i18nGetCatalog(object, locale) {
     var targetLocale;
 


### PR DESCRIPTION
This simple addition allows your app to write an updated catalog back to file. Meaning all translation management can be handled directly in your map and doesn't require someone to manually edit each translation file