### PR TITLE
objectNotation mutator fix

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -995,6 +995,10 @@ module.exports = (function() {
       var nullAccessor = function() {
         return null;
       };
+      // Fix object path.
+      var fixObject = function() {
+        return {};
+      };
       // Are we going to need to re-traverse the tree when the mutator is invoked?
       var reTraverse = false;
       // Split the provided term and run the callback for each subterm.
@@ -1006,6 +1010,10 @@ module.exports = (function() {
         if (null === object || !object.hasOwnProperty(index)) {
           // ...check if we're allowed to create new branches.
           if (allowBranching) {
+            // Fix `object` if `object` is not Object.
+            if (null === object || typeof object !== 'object') {
+              object = fixObject();
+            }
             // If we are allowed to, create a new object along the path.
             object[index] = {};
           } else {
@@ -1019,6 +1027,11 @@ module.exports = (function() {
         accessor = function(value) {
           object[index] = value;
           return value;
+        };
+        // Generate a fixer for the current level.
+        fixObject = function() {
+          object[index] = {};
+          return object[index];
         };
 
         // Return a reference to the next deeper level in the locale tree.

--- a/locales/en.json
+++ b/locales/en.json
@@ -25,9 +25,6 @@
 				"one": "plural",
 				"other": "plurals"
 			}
-		},
-		"path": {
-			"sub": "nested.path.sub"
 		}
 	},
 	"There is one monkey in the %%s": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -14,17 +14,20 @@
 		"other": "%s cats"
 	},
 	"cats": {
-    	"n": {
-      		"one": "%s cat",
-      		"other": "%s cats"
-    	}
-  	},
+		"n": {
+			"one": "%s cat",
+			"other": "%s cats"
+		}
+	},
 	"nested": {
 		"deep": {
 			"plural": {
 				"one": "plural",
 				"other": "plurals"
 			}
+		},
+		"path": {
+			"sub": "nested.path.sub"
 		}
 	},
 	"There is one monkey in the %%s": {
@@ -40,32 +43,24 @@
 		"one": "There is one monkey in the tree",
 		"other": "There are %d monkeys in the tree"
 	},
-
-	"plurals with intervals in string (no object)":"[0] a zero rule|[2,5] two to five (included)|and a catchall rule",
-
-	"plurals with intervals in _other_ missing _one_":{
+	"plurals with intervals in string (no object)": "[0] a zero rule|[2,5] two to five (included)|and a catchall rule",
+	"plurals with intervals in _other_ missing _one_": {
 		"other": "[0] a zero rule|[2,5] two to five (included)|and a catchall rule"
 	},
-
-	"plurals with intervals as string":{
+	"plurals with intervals as string": {
 		"one": "The default 'one' rule",
 		"other": "[0] a zero rule|[2,5] two to five (included)|and a catchall rule"
 	},
-
-	"plurals with intervals as string (excluded)":{
+	"plurals with intervals as string (excluded)": {
 		"one": "The default 'one' rule",
 		"other": "[0] a zero rule|]2,5[ two to five (excluded)|and a catchall rule"
 	},
-
-	"plurals in any order":{
+	"plurals in any order": {
 		"one": "The default 'one' rule",
 		"other": "[0] a zero rule|and a catchall rule|[2,5] two to five (included)"
 	},
-
-	"plurals to eternity":"[0,] this will last forever|but only gt 0",
-
-	"plurals from eternity":"[,0] this was born long before|but only lt 0",
-
+	"plurals to eternity": "[0,] this will last forever|but only gt 0",
+	"plurals from eternity": "[,0] this was born long before|but only lt 0",
 	"Hello %s": "Hello %s",
 	"Hello {{name}}": "Hello {{name}}",
 	"Hello {{name}}, how was your %s?": "Hello {{name}}, how was your %s?",
@@ -87,24 +82,24 @@
 		}
 	},
 	"another": {
-		"nested":{
-			"extra":{
-				"deep":{
-					"example":{
+		"nested": {
+			"extra": {
+				"deep": {
+					"example": {
 						"one": "The default 'one' rule",
 						"other": "[0] a zero rule|[2,5] two to five (included)|and a catchall rule"
 					}
 				},
-				"lazy":{
-					"example":{
+				"lazy": {
+					"example": {
 						"other": "[0] a zero rule|[2,5] two to five (included)|and a catchall rule"
 					}
 				},
-				"mustache":{
-					"example":"[0] a zero rule for {{me}}|[2,5] two to five (included) for {{me}}|and a catchall rule for {{me}}"
+				"mustache": {
+					"example": "[0] a zero rule for {{me}}|[2,5] two to five (included) for {{me}}|and a catchall rule for {{me}}"
 				},
-				"mustacheprintf":{
-					"example":"[0] %s is zero rule for {{me}}|[2,5] %s is between two and five (included) for {{me}}|and a catchall rule for {{me}} to get my number %s"
+				"mustacheprintf": {
+					"example": "[0] %s is zero rule for {{me}}|[2,5] %s is between two and five (included) for {{me}}|and a catchall rule for {{me}} to get my number %s"
 				}
 			}
 		}

--- a/test/i18n.objectnotation.js
+++ b/test/i18n.objectnotation.js
@@ -28,6 +28,12 @@ describe('Object Notation', function() {
   });
 
   describe('i18nTranslate', function() {
+
+    beforeEach(function() {
+      var catalog = i18n.getCatalog('en');
+      delete catalog.nested.path;
+    });
+
     it('should return en translations as expected, using object traversal notation', function() {
       i18n.setLocale('en');
       should.equal(__('greeting.formal'), 'Hello');
@@ -50,6 +56,14 @@ describe('Object Notation', function() {
       var plural = __n("nested.deep.plural", 3);
       should.equal(singular, 'plural');
       should.equal(plural, 'plurals');
+    });
+
+    it('should correctly update files', function() {
+      should.equal(__("nested.path"), "nested.path");
+      should.equal(__("nested.path.sub"), "nested.path.sub");
+      should.deepEqual(__("nested.path"), {
+        sub: "nested.path.sub"
+      });
     });
   });
 });


### PR DESCRIPTION
```js
// `test` is object
// `path` is not set
__('test.path') // returns 'test.path'
__('test.path.sub') // falls with error
```

After fix:

```js
// `test` is object
// `path` is not set
__('test.path') // returns 'test.path'
__('test.path.sub') // returns 'test.path.sub'
__('test.path') // returns {sub:'test.path.sub'}
```

