### PR TITLE
Updates for Missing Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ i18n.configure({
     logErrorFn: function (msg) {
         console.log('error', msg);
     },
+    
+    // custom function hook for missing translations
+    missingTranslation: function(locale, value){},
 
     // object or [obj1, obj2] to bind the i18n api and current locale to - defaults to null
     register: global,
@@ -941,6 +944,23 @@ i18n.configure({
     }
 });
 ```
+
+## Custom Missing Translation Function
+
+Sometimes, you might need to deal with a missing translation for a locale, either for a custom logging situation, or to add the translation to a 3rd party translation tool (like Zanata). You can do that through adding a missing trasnlation function which takes the locale and value that is missing a particular translation
+
+```js
+i18n.configure({
+
+    ...
+
+    // Dealing with a missing translation at a functional level
+    missingTranslation: function(locale, value){
+      console.log('%s is missing the following translation: %s', locale, value);
+    }
+});
+```
+
 
 [![NPM](https://nodei.co/npm/i18n.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/i18n/)
 

--- a/i18n.js
+++ b/i18n.js
@@ -54,6 +54,7 @@ module.exports = (function() {
     logDebugFn,
     logErrorFn,
     logWarnFn,
+    missingTranslation,
     objectNotation,
     prefix,
     queryParameter,
@@ -146,6 +147,10 @@ module.exports = (function() {
     logDebugFn = (typeof opt.logDebugFn === 'function') ? opt.logDebugFn : debug;
     logWarnFn = (typeof opt.logWarnFn === 'function') ? opt.logWarnFn : warn;
     logErrorFn = (typeof opt.logErrorFn === 'function') ? opt.logErrorFn : error;
+
+    // setting custom missing translation function
+
+    missingTranslation = (typeof opt.missingTranslation === 'function') ? opt.missingTranslation : function(locale, value){} 
 
     // when missing locales we try to guess that from directory
     opt.locales = opt.locales || guessLocales(directory);
@@ -842,11 +847,9 @@ module.exports = (function() {
 
     // fallback to default when missed
     if (!locales[locale]) {
-
       logWarn('WARN: Locale ' + locale +
         ' couldn\'t be read - check the context of the call to $__. Using ' +
         defaultLocale + ' (default) as current locale');
-
       locale = defaultLocale;
       read(locale);
     }
@@ -888,7 +891,6 @@ module.exports = (function() {
       mutator(defaultSingular || singular);
       write(locale);
     }
-
     return accessor();
   };
 
@@ -1053,6 +1055,7 @@ module.exports = (function() {
     } else {
       // No object notation, just return a mutator that performs array lookup and changes the value.
       return function(value) {
+        missingTranslation(locale, value);
         locales[locale][singular] = value;
         return value;
       };


### PR DESCRIPTION
Updates for Missing Translations, adds a passthrough that a user can
run a function hook to do something with the missing function