### PR TITLE
Allow calling i18n.init on objects without headers attribute

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -641,7 +641,7 @@ module.exports = (function() {
 
   var guessLanguage = function(request) {
     if (typeof request === 'object') {
-      var languageHeader = request.headers['accept-language'],
+      var languageHeader = request.headers? request.headers['accept-language'] : undefined,
         languages = [],
         regions = [];
 

--- a/test/i18n.init.js
+++ b/test/i18n.init.js
@@ -56,6 +56,16 @@ describe('i18n.init()', function() {
     done();
   });
 
+  it('should be possible to bind to non-request objects', function(done) {
+    var plain = new Object();
+    should.equal(i18n.init(plain), undefined);
+    should.equal(plain.locale, 'en');
+    should.equal(plain.__('Hello'), 'Hello');
+    should.equal(plain.setLocale('de'), 'de');
+    should.equal(plain.__('Hello'), 'Hallo');
+    done();
+  });
+
   it('should be possible to bind public methods to foreign objects', function(done){
     UnboundTestScope.translate = i18n.__;
     should.equal(UnboundTestScope.translate('Hello'), 'Hallo');


### PR DESCRIPTION
This simple change allows one to call `i18n.init` into any plain object, not only requests.

It is an important change for systems that have middlewares, but don't necessarily have a `request.headers` attribute, such as background workers that generate emails. Everything else already works with plain objects, it is just `.init` that requires this attribute.