### PR TITLE
Let locales in i18n export correctly

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -71,7 +71,7 @@ module.exports = (function() {
   i18n.configure = function i18nConfigure(opt) {
 
     // reset locales
-    locales = {};
+    i18n.locales = locales = {};
 
     // Provide custom API method aliases if desired
     // This needs to be processed before the first call to applyAPItoObject()

--- a/i18n.js
+++ b/i18n.js
@@ -71,7 +71,8 @@ module.exports = (function() {
   i18n.configure = function i18nConfigure(opt) {
 
     // reset locales
-    i18n.locales = locales = {};
+    locales = {};
+    i18n.locales = locales;
 
     // Provide custom API method aliases if desired
     // This needs to be processed before the first call to applyAPItoObject()

--- a/test/i18n.locales.js
+++ b/test/i18n.locales.js
@@ -1,0 +1,20 @@
+var i18n = require('../i18n'),
+  should = require("should");
+
+describe('Locales test', function () {
+
+  beforeEach(function () {
+
+    i18n.configure({
+      locales: ['en', 'de'],
+      directory: './locales',
+      register: global
+    });
+
+  });
+
+  it('locales will get all locales', function () {
+    i18n.locales['en']['Hello'].should.equal('Hello');
+    i18n.locales['de']['Hello'].should.equal('Hallo');
+  });
+});


### PR DESCRIPTION
I noticed that at line 67 in file i18n.js, the variable _locales_ want to be exported:
`i18n.locales = locales`
But at line 74, _locales_ is set to {}, so _i18n.locales_ will never refer _locales_:
`locales = {};`

I am not sure why you want to export _locales_ but not refer to the correct variable, so I send this pull request to fix this small issue.