### PR TITLE
Support for empty strings in translation files.

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -886,7 +886,7 @@ module.exports = (function() {
     var mutator = localeMutator(locale, singular);
 
     if (plural) {
-      if (!accessor()) {
+      if (accessor() == null) {
         mutator({
           'one': defaultSingular || singular,
           'other': defaultPlural || plural
@@ -895,7 +895,7 @@ module.exports = (function() {
       }
     }
 
-    if (!accessor()) {
+    if (accessor() == null) {
       mutator(defaultSingular || singular);
       write(locale);
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
+	"Empty": "",
 	"Hello": "Hello",
 	"Hello %s, how are you today?": "Hello %s, how are you today?",
 	"weekend": "weekend",

--- a/test/i18n.api.global.js
+++ b/test/i18n.api.global.js
@@ -61,6 +61,11 @@ describe('Module API', function() {
     });
 
     describe('i18nTranslate', function() {
+      it('should return an empty string if the translation is an empty string', function() {
+        i18n.setLocale('en');
+        should.equal(__('Empty'), '');
+      });
+
       it('should return en translations as expected', function() {
         i18n.setLocale('en');
         should.equal(__('Hello'), 'Hello');

--- a/test/i18n.api.local.js
+++ b/test/i18n.api.local.js
@@ -172,6 +172,13 @@ describe('Module API', function () {
         afterEach(function() {
           i18n.setLocale('en');
         });
+
+        it('should return an empty string if the translation is an empty string', function(done) {
+          i18n.setLocale(req, 'en').should.equal('en');
+          req.__('Empty').should.equal('');
+          done();
+        });
+
         it('has to use local translation in en', function (done) {
           i18n.setLocale(req, 'en').should.equal('en');
           req.__('Hello').should.equal('Hello');

--- a/test/i18n.missingPhrases.js
+++ b/test/i18n.missingPhrases.js
@@ -1,0 +1,69 @@
+/*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
+
+// now with coverage suport
+var i18n = require('../i18n'),
+    should = require("should");
+
+describe('Missing Phrases', function () {
+
+  beforeEach(function() {
+
+    i18n.configure({
+      locales: ['en', 'de'],
+      fallbacks: {'nl': 'de'},
+      directory: './locales',
+      updateFiles: false,
+      syncFiles: false
+    });
+
+  });
+
+  describe('Local Module API', function () {
+    var req = {
+      request: "GET /test",
+      __: i18n.__,
+      __n: i18n.__n,
+      locale: {},
+      headers: {}
+    };
+
+    beforeEach(function() {
+      i18n.configure({
+        locales: ['en', 'de', 'en-GB'],
+        defaultLocale: 'en',
+        directory: './locales',
+        register: req,
+        updateFiles: false,
+        syncFiles: false
+      });
+    });
+
+    describe('i18nTranslate', function () {
+      it('should return the key if the translation does not exist', function(done) {
+        i18n.setLocale(req, 'en').should.equal('en');
+        req.__('DoesNotExist').should.equal('DoesNotExist');
+        done();
+      });
+    });
+  });
+
+  describe('Global Module API', function () {
+    beforeEach(function() {
+      i18n.configure({
+        locales: ['en', 'de', 'en-GB'],
+        defaultLocale: 'en',
+        directory: './locales',
+        register: global,
+        updateFiles: false,
+        syncFiles: false
+      });
+    });
+
+    describe('i18nTranslate', function () {
+      it('should return the key if the translation does not exist', function() {
+        i18n.setLocale('en');
+        should.equal(__('DoesNotExist'), 'DoesNotExist');
+      });
+    });
+  });
+});


### PR DESCRIPTION
I currently have a use-case where I need to have an empty string in my translation file. Currently, i18n-node will replace this translation with the key, as it thinks that the translation does not exist. Here's an example:

```
en.json
{
    "AddToGroup.1": "Add to",
    "AddToGroup.2": "group"
}

fr.json
{
    "AddToGroup.1": "Ajouter au groupe",
    "AddToGroup.2": ""
}
```

Used like so;
```
__('AddToGroup.1') + '<strong>' + groupName + '</strong>' + __('AddToGroup.2')
```

Currently, this is output like so (with group name **X**):
English:
`Add to <strong>X</strong> group`

French:
`Ajouter au groupe <strong>X</strong> AddToGroup.2`

because i18n-node will replace the empty string for `AddToGroup.2` in French with the key `AddToGroup.2`.

This pull request fixes that by only replacing with the key if the translation key does not exist, rather than being empty string (was a basic falsey check where it should've been a check for null/undefined).

Also added some tests for this use case.


