### PR TITLE
updateFile directoryPermission fix

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -1130,10 +1130,9 @@ module.exports = (function() {
     try {
       target = getStorageFilePath(locale);
       tmp = target + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, indent), {
-        encofing: 'utf8',
-        mode: directoryPermissions
-      });
+      fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, indent), 'utf8');
+      fs.chmodSync(tmp, directoryPermissions);
+
       stats = fs.statSync(tmp);
       if (stats.isFile()) {
         fs.renameSync(tmp, target);

--- a/i18n.js
+++ b/i18n.js
@@ -1130,7 +1130,10 @@ module.exports = (function() {
     try {
       target = getStorageFilePath(locale);
       tmp = target + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, indent), 'utf8');
+      fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, indent), {
+        encofing: 'utf8',
+        mode: directoryPermissions
+      });
       stats = fs.statSync(tmp);
       if (stats.isFile()) {
         fs.renameSync(tmp, target);


### PR DESCRIPTION
When updating a file i18n overrides its permission to 644. I think parameter directoryPermissions should also work there, or you could create another parameter updateDirectoryPermissions.

I opt for first option.
