### PR TITLE
Missing devDependencies, jshint to eslint, fixed guard-for-in error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ branches:
   only:
     - master
     - stable
-before_install:
-  - "npm install -g istanbul"
 script:
   - "npm run test-ci"
 after_script:

--- a/i18n.js
+++ b/i18n.js
@@ -912,7 +912,9 @@ module.exports = (function() {
     // this will implicitly write/sync missing keys
     // to the rest of locales
     for (var l in locales) {
-      translate(l, singular, plural, true);
+      if ({}.hasOwnProperty.call(locales, l)) {
+        translate(l, singular, plural, true);
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "*",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
-    "istanbul": "^0.4.5",
+    "istanbul": "0.4.*",
     "jshint": "2.9.*",
     "mocha": "*",
     "should": "*",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "async": "*",
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
+    "istanbul": "^0.4.5",
     "jshint": "*",
     "mocha": "*",
     "should": "*",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "npm run jshint && make test",
-    "test-ci": "npm run jshint && istanbul cover ./node_modules/mocha/bin/_mocha"
+    "lint": "eslint .",
+    "test": "npm run lint && make test",
+    "test-ci": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cookie-parser": "^1.4.1",
     "express": "^4.13.4",
     "istanbul": "^0.4.5",
-    "jshint": "*",
+    "jshint": "2.9.*",
     "mocha": "*",
     "should": "*",
     "sinon": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "async": "*",
     "cookie-parser": "^1.4.1",
-    "eslint": "3.9.*",
+    "eslint": "3.5.*",
     "express": "^4.13.4",
     "istanbul": "0.4.*",
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "async": "*",
     "cookie-parser": "^1.4.1",
-    "eslint": "3.5.*",
+    "eslint": "2.13.*",
     "express": "^4.13.4",
     "istanbul": "0.4.*",
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "async": "*",
     "cookie-parser": "^1.4.1",
+    "eslint": "3.9.*",
     "express": "^4.13.4",
     "istanbul": "0.4.*",
-    "jshint": "2.9.*",
     "mocha": "*",
     "should": "*",
     "sinon": "*",
@@ -41,7 +41,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "jshint": "jshint --verbose .",
     "test": "npm run jshint && make test",
     "test-ci": "npm run jshint && istanbul cover ./node_modules/mocha/bin/_mocha"
   },


### PR DESCRIPTION
- istanbul is required for the test-ci script, but was missing from package.json
- there is a mix of jshint and eslint, so moved everything over to eslint. Pined at version 2.13.x for travisci tests to pass in jobs prior to LTS (4.0)
- fixed guard-for-in error identified by eslint