### PR TITLE
Guarding for-in loop from unexpected items

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -912,7 +912,9 @@ module.exports = (function() {
     // this will implicitly write/sync missing keys
     // to the rest of locales
     for (var l in locales) {
-      translate(l, singular, plural, true);
+      if ({}.hasOwnProperty.call(locales, l)) {
+        translate(l, singular, plural, true);
+      }
     }
   };
 


### PR DESCRIPTION
Identified by running eslint on project

Per http://eslint.org/docs/rules/guard-for-in

Looping over objects with a for in loop will include properties that
are inherited through the prototype chain. This behavior can lead to
unexpected items in your for loop.