### PR TITLE
Eslint and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ branches:
   only:
     - master
     - stable
-before_install:
-  - "npm install -g istanbul"
 script:
   - "npm run test-ci"
 after_script:

--- a/i18n.js
+++ b/i18n.js
@@ -912,7 +912,9 @@ module.exports = (function() {
     // this will implicitly write/sync missing keys
     // to the rest of locales
     for (var l in locales) {
-      translate(l, singular, plural, true);
+      if ({}.hasOwnProperty.call(locales, l)) {
+        translate(l, singular, plural, true);
+      }         
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   "devDependencies": {
     "async": "*",
     "cookie-parser": "^1.4.1",
+    "eslint": "^2.13.*",
     "express": "^4.13.4",
-    "jshint": "*",
+    "istanbul": "0.4.*",
     "mocha": "*",
     "should": "*",
     "sinon": "*",
@@ -40,9 +41,9 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "jshint": "jshint --verbose .",
-    "test": "npm run jshint && make test",
-    "test-ci": "npm run jshint && istanbul cover ./node_modules/mocha/bin/_mocha"
+    "lint": "eslint .",
+    "test": "npm run lint && make test",
+    "test-ci": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
- there was a mix of jshint and eslint, so moved everything over to eslint. Pined at version `2.13.*` for travisci tests to pass in jobs prior to LTS (4.0)
- fixed guard-for-in error identified by eslint
- istanbul is required for the `test-ci` script, but was missing from `package.json`
