### PR TITLE
tweaking so that the module gives us a way to make multiple i18n objects

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -24,7 +24,7 @@ var vsprintf = require('sprintf-js').vsprintf,
   parseInterval = require('math-interval-parser').default;
 
 // exports an instance
-module.exports = (function() {
+module.exports = function() {
 
   var MessageformatInstanceForLocale = {},
     PluralsForLocale = {},
@@ -1182,4 +1182,4 @@ module.exports = (function() {
 
   return i18n;
 
-}());
+};

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./i18n');
+module.exports = require('./i18n')();

--- a/test/i18n.api.global.js
+++ b/test/i18n.api.global.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 describe('Module API', function() {

--- a/test/i18n.api.local.js
+++ b/test/i18n.api.local.js
@@ -1,7 +1,7 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
 // now with coverage suport
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should");
 
 describe('Module API', function () {

--- a/test/i18n.configure.js
+++ b/test/i18n.configure.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs');
 

--- a/test/i18n.configureApi.js
+++ b/test/i18n.configureApi.js
@@ -1,11 +1,11 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should"),
     fs = require('fs'),
     path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 
 function reconfigure(config) {

--- a/test/i18n.configureAutoreload.js
+++ b/test/i18n.configureAutoreload.js
@@ -1,9 +1,9 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 var timeout = 50;
 

--- a/test/i18n.configureAutoreload.js
+++ b/test/i18n.configureAutoreload.js
@@ -191,3 +191,12 @@ describe('autoreload configuration with customextension', function() {
   });
 
 });
+
+describe('creating a new i18n object from i18n.js', function() {
+  var i18nAlternate = require('../i18n')();
+
+  it('should give me a different obejct', function() {
+    i18nAlternate.should.not.equal(i18n);
+  });
+
+});

--- a/test/i18n.configureCookiename.js
+++ b/test/i18n.configureCookiename.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.configureLocales.js
+++ b/test/i18n.configureLocales.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.configurePermissions.js
+++ b/test/i18n.configurePermissions.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path"),
   fs = require('fs');

--- a/test/i18n.configureQueryParameter.js
+++ b/test/i18n.configureQueryParameter.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.configureRegister.js
+++ b/test/i18n.configureRegister.js
@@ -1,11 +1,11 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should"),
     fs = require('fs'),
     path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 
 function reconfigure(config) {

--- a/test/i18n.defaults.js
+++ b/test/i18n.defaults.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs');
 

--- a/test/i18n.fallbacks.js
+++ b/test/i18n.fallbacks.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 
@@ -94,7 +94,7 @@ describe('Fallbacks', function() {
   describe('Fallback to locale', function() {
     beforeEach(function() {
       // Force reloading of i18n, to reset configuration
-      var i18nPath = 'i18n';
+      var i18nPath = 'index';
       var i18nFilename = path.resolve(i18nPath + '.js');
       delete require.cache[i18nFilename];
       i18n = require(i18nFilename);
@@ -129,7 +129,7 @@ describe('Fallbacks', function() {
   describe('Keep valid locale', function() {
     beforeEach(function() {
       // Force reloading of i18n, to reset configuration
-      var i18nPath = 'i18n';
+      var i18nPath = 'index';
       var i18nFilename = path.resolve(i18nPath + '.js');
       delete require.cache[i18nFilename];
       i18n = require(i18nFilename);

--- a/test/i18n.init.js
+++ b/test/i18n.init.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   sinon = require("sinon"),
   fs = require('fs');

--- a/test/i18n.listsHashes.js
+++ b/test/i18n.listsHashes.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.makePlurals.js
+++ b/test/i18n.makePlurals.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.mf.js
+++ b/test/i18n.mf.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.objectnotation.js
+++ b/test/i18n.objectnotation.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n');
+var i18n = require('../index');
 var should = require("should");
 
 describe('Object Notation', function() {

--- a/test/i18n.plurals.js
+++ b/test/i18n.plurals.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 // reserve a "private" scope

--- a/test/i18n.setLocale.js
+++ b/test/i18n.setLocale.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.setLocaleDefaultLanguage.js
+++ b/test/i18n.setLocaleDefaultLanguage.js
@@ -4,7 +4,7 @@
  * req.setLocale("locale") sets defaultLanguage when req.locals is not defined #166
  *
  */
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.setup.js
+++ b/test/i18n.setup.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should");
 
 i18n.configure({

--- a/test/i18n.verifyLocaleSelectionMethods.js
+++ b/test/i18n.verifyLocaleSelectionMethods.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 describe('when configuring selected locale', function () {

--- a/test/i18n.writenewPhrase.js
+++ b/test/i18n.writenewPhrase.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');


### PR DESCRIPTION
It's a common process to have different i18n files for different parts of a project. Sometimes we want to be able to use different i18n configurations in environments and jump back and forth between which one we're using (think async build process). This change would be non-breaking for those who are using index.js (implicitly or explicitly) but also allow to build multiple unique i18n objects by going to i18n.js directly when needed. 

Is this something you'd consider supporting in this project?