### PR TITLE
Upgrade messageformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "*",
     "make-plural": "^3.0.3",
     "math-interval-parser": "^1.1.0",
-    "messageformat": "^0.3.1",
+    "messageformat": "^1.0.2",
     "mustache": "*",
     "sprintf-js": ">=1.0.3"
   },

--- a/test/i18n.mf.js
+++ b/test/i18n.mf.js
@@ -74,11 +74,11 @@ describe('parsing Messageformat phrases', function() {
     mfTest.setLocale('ru');
     should.equal('In russian there are zero for 0', mfTest.__mf(msg, { NUM: 0, lang: 'russian' }));
     should.equal('In russian there is one for 1', mfTest.__mf(msg, { NUM: 1, lang: 'russian' }));
-    should.equal('In russian there are a few for 2', mfTest.__mf(msg, { NUM: 2, lang: 'russian' }));
-    should.equal('In russian there are a few for 3', mfTest.__mf(msg, { NUM: 3, lang: 'russian' }));
-    should.equal('In russian there are a few for 4', mfTest.__mf(msg, { NUM: 4, lang: 'russian' }));
-    should.equal('In russian there are many for 5', mfTest.__mf(msg, { NUM: 5, lang: 'russian' }));
-    should.equal('In russian there are many for 6', mfTest.__mf(msg, { NUM: 6, lang: 'russian' }));
+    should.equal('In russian there others for 2', mfTest.__mf(msg, { NUM: 2, lang: 'russian' }));
+    should.equal('In russian there others for 3', mfTest.__mf(msg, { NUM: 3, lang: 'russian' }));
+    should.equal('In russian there others for 4', mfTest.__mf(msg, { NUM: 4, lang: 'russian' }));
+    should.equal('In russian there others for 5', mfTest.__mf(msg, { NUM: 5, lang: 'russian' }));
+    should.equal('In russian there others for 6', mfTest.__mf(msg, { NUM: 6, lang: 'russian' }));
     should.equal('In russian there is one for 21', mfTest.__mf(msg, { NUM: 21, lang: 'russian' }));
   });
 });

--- a/test/i18n.mf.js
+++ b/test/i18n.mf.js
@@ -40,15 +40,12 @@ describe('parsing Messageformat phrases', function() {
 
   it('should work with plurals', function() {
     var msg = 'In {lang} there {NUM, plural,';
-    msg += 'zero{are zero for #}';
+    msg += '=0{are zero for #}';
     msg += 'one{is one for #}';
-    msg += 'two{is two for #}';
-    msg += 'few{are a few for #}';
-    msg += 'many{are many for #}';
     msg += 'other{others for #}}';
 
     mfTest.setLocale('en');
-    should.equal('In english there others for 0', mfTest.__mf(msg, { NUM: 0, lang: 'english' }));
+    should.equal('In english there are zero for 0', mfTest.__mf(msg, { NUM: 0, lang: 'english' }));
     should.equal('In english there is one for 1', mfTest.__mf(msg, { NUM: 1, lang: 'english' }));
     should.equal('In english there others for 2', mfTest.__mf(msg, { NUM: 2, lang: 'english' }));
     should.equal('In english there others for 3', mfTest.__mf(msg, { NUM: 3, lang: 'english' }));
@@ -57,7 +54,7 @@ describe('parsing Messageformat phrases', function() {
     should.equal('In english there others for 6', mfTest.__mf(msg, { NUM: 6, lang: 'english' }));
 
     mfTest.setLocale('de');
-    should.equal('In german there others for 0', mfTest.__mf(msg, { NUM: 0, lang: 'german' }));
+    should.equal('In german there are zero for 0', mfTest.__mf(msg, { NUM: 0, lang: 'german' }));
     should.equal('In german there is one for 1', mfTest.__mf(msg, { NUM: 1, lang: 'german' }));
     should.equal('In german there others for 2', mfTest.__mf(msg, { NUM: 2, lang: 'german' }));
     should.equal('In german there others for 3', mfTest.__mf(msg, { NUM: 3, lang: 'german' }));
@@ -66,7 +63,7 @@ describe('parsing Messageformat phrases', function() {
     should.equal('In german there others for 6', mfTest.__mf(msg, { NUM: 6, lang: 'german' }));
 
     mfTest.setLocale('fr');
-    should.equal('In french there is one for 0', mfTest.__mf(msg, { NUM: 0, lang: 'french' }));
+    should.equal('In french there are zero for 0', mfTest.__mf(msg, { NUM: 0, lang: 'french' }));
     should.equal('In french there is one for 1', mfTest.__mf(msg, { NUM: 1, lang: 'french' }));
     should.equal('In french there others for 2', mfTest.__mf(msg, { NUM: 2, lang: 'french' }));
     should.equal('In french there others for 3', mfTest.__mf(msg, { NUM: 3, lang: 'french' }));
@@ -75,7 +72,7 @@ describe('parsing Messageformat phrases', function() {
     should.equal('In french there others for 6', mfTest.__mf(msg, { NUM: 6, lang: 'french' }));
 
     mfTest.setLocale('ru');
-    should.equal('In russian there are many for 0', mfTest.__mf(msg, { NUM: 0, lang: 'russian' }));
+    should.equal('In russian there are zero for 0', mfTest.__mf(msg, { NUM: 0, lang: 'russian' }));
     should.equal('In russian there is one for 1', mfTest.__mf(msg, { NUM: 1, lang: 'russian' }));
     should.equal('In russian there are a few for 2', mfTest.__mf(msg, { NUM: 2, lang: 'russian' }));
     should.equal('In russian there are a few for 3', mfTest.__mf(msg, { NUM: 3, lang: 'russian' }));

--- a/test/i18n.writenewPhrase.js
+++ b/test/i18n.writenewPhrase.js
@@ -119,11 +119,8 @@ describe('when i18n gets a new phrase', function() {
 
   it('should add translations with messageformat by use of __mf()', function(done) {
     var msg = 'In {language} there {N, plural,';
-    msg += 'zero{are zero for # }';
+    msg += '=0{are zero for # }';
     msg += 'one{is one for # }';
-    msg += 'two{is two for # }';
-    msg += 'few{are a few for # }';
-    msg += 'many{are many for # }';
     msg += 'other{others for # }';
     msg += '}';
 


### PR DESCRIPTION
Update `messageformat` dependency and update tests according to doc : https://github.com/messageformat/messageformat.js

This is solving installing `i18n` with npm 5.4 since it's cause by this dependency. 

Also, this is a break change update of messageformat so, I don't understand why `should work with plurals` was "other" instead of "zero" for effective "0" input.

In an other way, "zero", "two", "few" and "many" doesn't work any more so, this is probably a break changing.

After that, it's a npm error and not here.

Closes #325 