### PR TITLE
Feature; memory source

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -522,6 +522,7 @@ module.exports = (function() {
     delete locales[locale];
   };
 
+  i18n.willUpdateFiles = function(){ return updateFiles; };
   // ===================
   // = private methods =
   // ===================

--- a/i18n.js
+++ b/i18n.js
@@ -100,11 +100,7 @@ module.exports = (function() {
       }
     }
 
-    memorySource = undefined;
-
-    if (typeof opt.data === 'object') {
-      memorySource = opt.data;
-    }
+    memorySource = (['object', 'function'].indexOf(typeof opt.data) !== -1) ? opt.data : undefined;
 
     // sets a custom cookie name to parse locale settings from
     cookiename = (typeof opt.cookie === 'string') ? opt.cookie : null;
@@ -631,6 +627,10 @@ module.exports = (function() {
       return Object.keys(memorySource);
     }
 
+    if (typeof memorySource === 'function') {
+      return Object.keys(memorySource());
+    }
+
     var entries = fs.readdirSync(directory);
     var localesFound = [];
 
@@ -1090,6 +1090,11 @@ module.exports = (function() {
   var read = function(locale) {
     if (typeof memorySource === 'object' ) {
       locales[locale] = memorySource[locale]; // TODO; create clone?
+      return ;
+    }
+
+    if (typeof memorySource === 'function' ) {
+      locales[locale] = memorySource()[locale]; // TODO; create clone?
       return ;
     }
 

--- a/test/i18n.configureData.js
+++ b/test/i18n.configureData.js
@@ -14,10 +14,16 @@ function reconfigure(config) {
 describe('data api', function() {
   it('any data set in the data option becomes the in-memory source of all translations', function() {
     reconfigure({
-      data: { 'en': {}, 'it': {}, 'de': {} }
+      data: {
+        'en': {'wazzup': 'What\'s up'},
+        'it': {wazzup: 'Che cosa succede'},
+        'de': {wazzup: 'Wie geht\'s'} }
     });
 
-    should.equal(i18n.getLocales().sort(), ['de', 'en', 'it']);
+    should.equal(i18n.getLocales().sort().join(','), ['de', 'en', 'it'].join(','));
     should.equal(i18n.willUpdateFiles(), false);
+    should.equal(i18n.__('wazzup'), 'What\'s up');
+    i18n.setLocale('it');
+    should.equal(i18n.__('wazzup'), 'Che cosa succede');
   });
 });

--- a/test/i18n.configureData.js
+++ b/test/i18n.configureData.js
@@ -1,0 +1,23 @@
+var i18n = require('../i18n'),
+  should = require("should"),
+  path = require("path");
+
+var i18nPath = 'i18n';
+var i18nFilename = path.resolve(i18nPath + '.js');
+
+function reconfigure(config) {
+  delete require.cache[i18nFilename];
+  i18n = require(i18nFilename);
+  i18n.configure(config);
+};
+
+describe('data api', function() {
+  it('any data set in the data option becomes the in-memory source of all translations', function() {
+    reconfigure({
+      data: { 'en': {}, 'it': {}, 'de': {} }
+    });
+
+    should.equal(i18n.getLocales().sort(), ['de', 'en', 'it']);
+    should.equal(i18n.willUpdateFiles(), false);
+  });
+});

--- a/test/i18n.configureData.js
+++ b/test/i18n.configureData.js
@@ -15,9 +15,9 @@ describe('data api', function() {
   it('any data set in the data option becomes the in-memory source of all translations', function() {
     reconfigure({
       data: {
-        'en': {'wazzup': 'What\'s up'},
+        'en': {wazzup: 'What\'s up'},
         'it': {wazzup: 'Che cosa succede'},
-        'de': {wazzup: 'Wie geht\'s'} }
+        'de': {wazzup: 'Wie geht\'s'}}
     });
 
     should.equal(i18n.getLocales().sort().join(','), ['de', 'en', 'it'].join(','));
@@ -25,5 +25,25 @@ describe('data api', function() {
     should.equal(i18n.__('wazzup'), 'What\'s up');
     i18n.setLocale('it');
     should.equal(i18n.__('wazzup'), 'Che cosa succede');
+    should.equal(i18n.__({phrase: 'wazzup', locale: 'de'}), 'Wie geht\'s');
+
+  });
+
+  it('data can also be a function', function() {
+    reconfigure({
+      data: function(){
+        return {
+          'en': {allgood: 'All good'},
+          'it': {allgood: 'Tutto apposto'},
+          'de': {allgood: 'Alles klar'} };
+      }
+    });
+
+    should.equal(i18n.getLocales().sort().join(','), ['de', 'en', 'it'].join(','));
+    should.equal(i18n.willUpdateFiles(), false);
+    should.equal(i18n.__('allgood'), 'All good');
+    i18n.setLocale('it');
+    should.equal(i18n.__('allgood'), 'Tutto apposto');
+    should.equal(i18n.__({phrase: 'allgood', locale: 'de'}), 'Alles klar');
   });
 });


### PR DESCRIPTION
This feature adds a new configuration option; 'data' which lets the caller provide pre-loaded localisation data (basically bypassing all file-loading and -writing inside i18n).

### why? 
I needed this in my app, because I'm using the electron frameworks to run a web-application as cross-platform native-application in disguise. I'm using the electron-react-boilerplate and this provides a very convenient webpack workflow where you can just import json data files, just like any .js source-files and it will be automatically packaged with the application when creating a release-build. 

Supporting the 'traditional' node readFileSync of external files would require other ways of managing data files.
