### PR TITLE
Add custom file format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,28 @@ that file can be edited or just uploaded to [webtranslateit](http://docs.webtran
 }
 ```
 
+### Using a custom file format
+
+By default, `JSON.parse()` will be used to read files and `JSON.stringify()` will be used to write new strings to language files.
+
+It is, however, possible to specify your own parser, by setting `parser` and `reverseParser` keys in the `.configure` method. It's useful if you want to use other file formats, such as Ini files or YAML, instead of JSON, to write your language files. For example:
+
+```javascript
+i18n.configure({
+  extension: '.lang', // you'll probably not want to use .json
+  parser: function(fileContents) {
+    
+  },
+  reverseParser: function(obj) {
+
+  }
+});
+```
+
+As these functions are meant to replace `JSON.parse()` and `JSON.stringify()` respectively, their workflow must be the very same: `parser` receives a Buffer (which can be converted to string by using `fileContents.toString()`) and shall return a object (exactly like `JSON.parse()` would do). At the same way, `reverseParser` receives an object and must return a string, encoded in the format that your parser is able to read.
+
+When using a custom file format, you must specify both `parser` and `reverseParser`.
+
 ## Logging & Debugging
 
 Logging any kind of output is moved to [debug](https://github.com/visionmedia/debug) module. To let i18n output anything run your app with `DEBUG` env set like so:

--- a/i18n.js
+++ b/i18n.js
@@ -140,6 +140,10 @@ module.exports = (function() {
     objectNotation = (typeof opt.objectNotation !== 'undefined') ? opt.objectNotation : false;
     if (objectNotation === true) objectNotation = '.';
 
+    // allow other parsing method than JSON.parse
+    parser = (typeof opt.parser === 'function') ? opt.parser : JSON.parse;
+    reverseParser = (typeof opt.reverseParser === 'function') ? opt.reverseParser : JSON.stringify;
+
     // read language fallback map
     fallbacks = (typeof opt.fallbacks === 'object') ? opt.fallbacks : {};
 
@@ -176,10 +180,6 @@ module.exports = (function() {
         });
       }
     }
-
-    // allow other parsing method than JSON.parse
-    parser = (typeof opt.parser === 'function') ? opt.parser : JSON.parse;
-    reverseParser = (typeof opt.reverseParser === 'function') ? opt.reverseParser : JSON.stringify;
   };
 
   i18n.init = function i18nInit(request, response, next) {
@@ -373,7 +373,7 @@ module.exports = (function() {
       } else {
         // split locales with a region code
         var lc = targetLocale.toLowerCase().split(/[_-\s]+/)
-          .filter(function(el){ return true && el; });
+          .filter(function(el) { return true && el; });
         // take the first part of locale, fallback to full locale
         p = new MakePlural(lc[0] || targetLocale);
         PluralsForLocale[targetLocale] = p;
@@ -653,7 +653,7 @@ module.exports = (function() {
 
   var guessLanguage = function(request) {
     if (typeof request === 'object') {
-      var languageHeader = request.headers? request.headers['accept-language'] : undefined,
+      var languageHeader = request.headers ? request.headers['accept-language'] : undefined,
         languages = [],
         regions = [];
 
@@ -700,7 +700,7 @@ module.exports = (function() {
             // where the original, unsupported language existed.
             var acceptedLanguageIndex = acceptedLanguages.indexOf(lang);
             var fallbackIndex = acceptedLanguages.indexOf(fallback);
-            if(fallbackIndex > -1) {
+            if (fallbackIndex > -1) {
               acceptedLanguages.splice(fallbackIndex, 1);
             }
             acceptedLanguages.splice(acceptedLanguageIndex + 1, 0, fallback);
@@ -1089,6 +1089,7 @@ module.exports = (function() {
         // parsing filecontents to locales[locale]
         locales[locale] = parser(localeFile);
       } catch (parseError) {
+        console.log(parseError)
         logError('unable to parse locales from file (maybe ' +
           file + ' is empty or invalid json?): ', parseError);
       }

--- a/i18n.js
+++ b/i18n.js
@@ -60,7 +60,9 @@ module.exports = (function() {
     queryParameter,
     register,
     updateFiles,
-    syncFiles;
+    syncFiles,
+    parser,
+    reverseParser;
 
   // public exports
   var i18n = {};
@@ -174,6 +176,10 @@ module.exports = (function() {
         });
       }
     }
+
+    // allow other parsing method than JSON.parse
+    parser = (typeof opt.parser === 'function') ? opt.parser : JSON.parse;
+    reverseParser = (typeof opt.reverseParser === 'function') ? opt.reverseParser : JSON.stringify;
   };
 
   i18n.init = function i18nInit(request, response, next) {
@@ -1081,7 +1087,7 @@ module.exports = (function() {
       localeFile = fs.readFileSync(file);
       try {
         // parsing filecontents to locales[locale]
-        locales[locale] = JSON.parse(localeFile);
+        locales[locale] = parser(localeFile);
       } catch (parseError) {
         logError('unable to parse locales from file (maybe ' +
           file + ' is empty or invalid json?): ', parseError);
@@ -1130,7 +1136,7 @@ module.exports = (function() {
     try {
       target = getStorageFilePath(locale);
       tmp = target + '.tmp';
-      fs.writeFileSync(tmp, JSON.stringify(locales[locale], null, indent), 'utf8');
+      fs.writeFileSync(tmp, reverseParser(locales[locale], null, indent), 'utf8');
       stats = fs.statSync(tmp);
       if (stats.isFile()) {
         fs.renameSync(tmp, target);

--- a/i18n.js
+++ b/i18n.js
@@ -1089,7 +1089,6 @@ module.exports = (function() {
         // parsing filecontents to locales[locale]
         locales[locale] = parser(localeFile);
       } catch (parseError) {
-        console.log(parseError)
         logError('unable to parse locales from file (maybe ' +
           file + ' is empty or invalid json?): ', parseError);
       }


### PR DESCRIPTION
My i18n crew isn't  made of JSON fans, and although I know JSON is very suitable for doing i18n stuff (since most i18n platforms do accept it), I had to replace JSON with a variant format in my current project.

This PR allows the developer to provide his own parsing/unparsing methods. Thus it's possible to use .po/.mo, YAML, ini files, XML or any other file format the developer <s>wants to</s> must use.

Here's an example replacing JSON with [NEON](https://github.com/matej21/neon-js):

```javascript
var i18n = require('i18n')
var neon = require('neon-js')

var parsingFn = function(fileContents) {
	return neon.decode(fileContents.toString()).toObject(true)
}

var unparsingFn = function(obj) {
	return neon.encode(obj, neon.BLOCK)
}

i18n.configure({
	locales: ['es'],
	defaultLocale: 'es',
	directory: __dirname + '/locales',
	extension: '.lang',
	objectNotation: true,
	parser: parsingFn,
	reverseParser: unparsingFn
})

// simple example
console.log(i18n.__('Hello')) // Hola

// testing objectNotation
console.log(i18n.__('greetings.morning', 'John')) // Buenos dias, John!

// testing a string that does not exist, so it will use reverseParser
console.log(i18n.__('foo'))
```

The language file "locales/es.lang" is:
```
Hello: Hola
greetings:
	morning: "Buenos dias, %s!"
```

Whereas, supporting YAML is as simple as:

```javascript
var i18n = require('i18n')
var yaml = require('js-yaml')

i18n.configure({
	locales: ['es'],
	defaultLocale: 'es',
	directory: __dirname + '/locales',
	extension: '.lang',
	objectNotation: true,
	parser: yaml.safeLoad,
	reverseParser: yaml.safeDump
})
```