### PR TITLE
Use fixed package version of debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lib": "."
   },
   "dependencies": {
-    "debug": "*",
+    "debug": "3.2.5",
     "make-plural": "^3.0.3",
     "math-interval-parser": "^1.1.0",
     "messageformat": "^0.3.1",


### PR DESCRIPTION
debug package has dropped support of node 4 so using older version `3.2.5` of debug module.

source: https://github.com/visionmedia/debug/releases/tag/4.0.0