### PR TITLE
Only do pluralization with ranged interval support if __n is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ __n('dogs', 20) // --> too many dogs
 __n('dogs', 199) // --> too many dogs
 
 // no interval returned, but found a catchall
-__('dogs') // --> too many dogs
+__n('dogs') // --> too many dogs
 ```
 
 See [en.json example](https://github.com/mashpie/i18n-node/blob/master/locales/en.json) inside `/locales` for some inspiration on use cases. Each phrase might get decorated further with mustache and sprintf expressions:

--- a/i18n.js
+++ b/i18n.js
@@ -529,7 +529,7 @@ module.exports = (function() {
   var postProcess = function(msg, namedValues, args, count) {
 
     // test for parsable interval string
-    if ((/\|/).test(msg)) {
+    if ((/\|/).test(msg) && (typeof count !== 'undefined')) {
       msg = parsePluralInterval(msg, count);
     }
 

--- a/i18n.js
+++ b/i18n.js
@@ -60,7 +60,8 @@ module.exports = (function() {
     queryParameter,
     register,
     updateFiles,
-    syncFiles;
+    syncFiles,
+    mustache;
 
   // public exports
   var i18n = {};
@@ -151,6 +152,9 @@ module.exports = (function() {
 
     // when missing locales we try to guess that from directory
     opt.locales = opt.locales || guessLocales(directory);
+
+    mustache = (typeof opt.mustache === 'undefined') ?
+      true : opt.mustache;
 
     // implicitly read all locales
     if (Array.isArray(opt.locales)) {
@@ -539,7 +543,7 @@ module.exports = (function() {
     }
 
     // if the msg string contains {{Mustache}} patterns we render it as a mini tempalate
-    if ((/{{.*}}/).test(msg)) {
+    if (mustache && (/{{.*}}/).test(msg)) {
       msg = Mustache.render(msg, namedValues);
     }
 


### PR DESCRIPTION
According to the documentation, pluralization is only done with `__n()`. But the ranged interval support was still being applied when using `__()`. Because of this, it was not possible to use "|" anywhere in the string being localized. This broke my templates since I needed to use "|" in my translations.

I added a check to see if a count is defined before applying plural interval on the string. That way only calls using the __n will be affected (calling __n without a parameter will still assign count to NaN which makes the fallback work). I updated the readme to indicate that you have to use __n for any kind for any kind of ranged interval support. 