### PR TITLE
Make the language source header customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ i18n.configure({
 
     // sets a custom cookie name to parse locale settings from - defaults to NULL
     cookie: 'yourcookiename',
+	
+	// sets a custom header name to read the language preference from - accept-language header by default
+	header: 'accept-language',
 
     // query parameter to switch locale (ie. /home?lang=ch) - defaults to NULL
     queryParameter: 'lang',

--- a/i18n.js
+++ b/i18n.js
@@ -45,6 +45,7 @@ module.exports = (function() {
     pathsep = path.sep, // ---> means win support will be available in node 0.8.x and above
     autoReload,
     cookiename,
+	languageHeaderName,
     defaultLocale,
     directory,
     directoryPermissions,
@@ -101,6 +102,9 @@ module.exports = (function() {
 
     // sets a custom cookie name to parse locale settings from
     cookiename = (typeof opt.cookie === 'string') ? opt.cookie : null;
+	
+	// set the custom header name to extract the language locale
+    languageHeaderName = (typeof opt.header === 'string') ? opt.header : 'accept-language';
 
     // query-string parameter to be watched - @todo: add test & doc
     queryParameter = (typeof opt.queryParameter === 'string') ? opt.queryParameter : null;
@@ -647,7 +651,7 @@ module.exports = (function() {
 
   var guessLanguage = function(request) {
     if (typeof request === 'object') {
-      var languageHeader = request.headers? request.headers['accept-language'] : undefined,
+      var languageHeader = request.headers? request.headers[languageHeaderName] : undefined,
         languages = [],
         regions = [];
 


### PR DESCRIPTION
Config object now accepts 'header' option to customize which header it should read the language from