### PR TITLE
fix: try/catch fs.mkdirSync case of parallel tasks utilizing in same dir

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -1120,7 +1120,12 @@ module.exports = (function() {
       stats = fs.lstatSync(directory);
     } catch (e) {
       logDebug('creating locales dir in: ' + directory);
-      fs.mkdirSync(directory, directoryPermissions);
+      try {
+        fs.mkdirSync(directory, directoryPermissions);
+      } catch (e) {
+        // in case of parallel tasks utilizing in same dir
+        if (e.code !== 'EEXIST') throw e;
+      }
     }
 
     // first time init has an empty file


### PR DESCRIPTION
If you have multiple tasks running in parallel that all rely upon the `locales` dir to be created, sometimes they run so fast together than the `fs.mkdirSync` errors due to I/O.  This prevents the error from being thrown if the error had the code of `EEXIST`, which would indicate the directory has already been created.

cc @shaunwarman