### PR TITLE
Missing Key Function (fixes #333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stores language files in json files compatible to [webtranslateit](http://webtra
 Adds new strings on-the-fly when first used in your app.
 No extra parsing needed.
 
-[![Travis][travis-image]][travis-url] 
+[![Travis][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
 [![NPM version][npm-image]][npm-url]
 ![npm](https://img.shields.io/npm/dw/i18n)
@@ -192,6 +192,11 @@ i18n.configure({
         console.log('error', msg);
     },
 
+    // used to alter the behaviour of missing keys
+    missingKeyFn: function (locale, value) {
+        return value;
+    },
+
     // object or [obj1, obj2] to bind the i18n api and current locale to - defaults to null
     register: global,
 
@@ -346,7 +351,7 @@ __n('%s cat', 3) // --> 3 Katzen
 
 // long syntax works fine in combination with `updateFiles`
 // --> writes '%s cat' to `one` and '%s cats' to `other` plurals
-// "one" (singular) & "other" (plural) just covers the basic Germanic Rule#1 correctly. 
+// "one" (singular) & "other" (plural) just covers the basic Germanic Rule#1 correctly.
 __n("%s cat", "%s cats", 1); // 1 Katze
 __n("%s cat", "%s cats", 3); // 3 Katzen
 

--- a/i18n.js
+++ b/i18n.js
@@ -57,7 +57,8 @@ module.exports = (function() {
     queryParameter,
     register,
     updateFiles,
-    syncFiles;
+    syncFiles,
+    missingKeyFn;
 
   // public exports
   var i18n = {};
@@ -146,15 +147,22 @@ module.exports = (function() {
     preserveLegacyCase = (typeof opt.preserveLegacyCase === 'undefined') ?
       true : opt.preserveLegacyCase;
 
+    // setting custom missing key function
+    missingKeyFn = (typeof opt.missingKeyFn === 'function') ? opt.missingKeyFn : missingKey;
+
     // when missing locales we try to guess that from directory
-    opt.locales = opt.locales || guessLocales(directory);
+    opt.locales = opt.staticCatalog ? Object.keys(opt.staticCatalog) : opt.locales || guessLocales(directory);
 
     // implicitly read all locales
     if (Array.isArray(opt.locales)) {
 
-      opt.locales.forEach(function(l) {
-        read(l);
-      });
+      if (opt.staticCatalog) {
+        locales = opt.staticCatalog;
+      } else {
+        opt.locales.forEach(function(l) {
+          read(l);
+        });
+      }
 
       // auto reload locale files when changed
       if (autoReload) {
@@ -1060,12 +1068,14 @@ module.exports = (function() {
         // invoke the search again, but allow branching
         // this time (because here the mutator is being invoked)
         // otherwise, just change the value directly.
+        value = missingKeyFn(locale, value);
         return (reTraverse) ? localeMutator(locale, singular, true)(value) : accessor(value);
       };
 
     } else {
       // No object notation, just return a mutator that performs array lookup and changes the value.
       return function(value) {
+        value = missingKeyFn(locale, value);
         locales[locale][singular] = value;
         return value;
       };
@@ -1185,6 +1195,13 @@ module.exports = (function() {
 
   function logError(msg) {
     logErrorFn(msg);
+  }
+
+  /**
+   * Missing key function
+   */
+  function missingKey(locale, value) {
+    return value;
   }
 
   return i18n;

--- a/test/i18n.missingPhrases.js
+++ b/test/i18n.missingPhrases.js
@@ -27,42 +27,73 @@ describe('Missing Phrases', function () {
       headers: {}
     };
 
-    beforeEach(function() {
-      i18n.configure({
-        locales: ['en', 'de', 'en-GB'],
-        defaultLocale: 'en',
-        directory: './locales',
-        register: req,
-        updateFiles: false,
-        syncFiles: false
-      });
-    });
-
     describe('i18nTranslate', function () {
       it('should return the key if the translation does not exist', function(done) {
+        i18n.configure({
+          locales: ['en', 'de', 'en-GB'],
+          defaultLocale: 'en',
+          directory: './locales',
+          register: req,
+          updateFiles: false,
+          syncFiles: false
+        });
+
         i18n.setLocale(req, 'en').should.equal('en');
         req.__('DoesNotExist').should.equal('DoesNotExist');
+        done();
+      });
+
+      it('should return a custom key if a missing key function is provided', function(done) {
+        i18n.configure({
+          locales: ['en', 'de', 'en-GB'],
+          defaultLocale: 'en',
+          directory: './locales',
+          register: req,
+          updateFiles: false,
+          syncFiles: false,
+          missingKeyFn: function(locale, value) {
+            return 'DoesReallyNotExist';
+          }
+        });
+
+        i18n.setLocale(req, 'en').should.equal('en');
+        req.__n('DoesNotExist.sss.xxx').should.equal('DoesReallyNotExist');
         done();
       });
     });
   });
 
   describe('Global Module API', function () {
-    beforeEach(function() {
-      i18n.configure({
-        locales: ['en', 'de', 'en-GB'],
-        defaultLocale: 'en',
-        directory: './locales',
-        register: global,
-        updateFiles: false,
-        syncFiles: false
-      });
-    });
-
     describe('i18nTranslate', function () {
       it('should return the key if the translation does not exist', function() {
+        i18n.configure({
+          locales: ['en', 'de', 'en-GB'],
+          defaultLocale: 'en',
+          directory: './locales',
+          register: global,
+          updateFiles: false,
+          syncFiles: false
+        });
+
         i18n.setLocale('en');
         should.equal(__('DoesNotExist'), 'DoesNotExist');
+      });
+
+      it('should return a custom key if a missing key function is provided', function() {
+        i18n.configure({
+          locales: ['en', 'de', 'en-GB'],
+          defaultLocale: 'en',
+          directory: './locales',
+          register: global,
+          updateFiles: false,
+          syncFiles: false,
+          missingKeyFn: function(locale, value) {
+            return 'DoesReallyNotExist';
+          }
+        });
+
+        i18n.setLocale('en');
+        should.equal(__('DoesNotExist'), 'DoesReallyNotExist');
       });
     });
   });


### PR DESCRIPTION
Can be used to return static error strings (e.g. "[MISSING TRANSLATION]") to make it easy to detect by CI. Or to do have some custom error logic.