### PR TITLE
Supporting standalone pipe characters

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -544,7 +544,6 @@ module.exports = (function() {
   var postProcess = function(msg, namedValues, args, count) {
 
     // test for parsable interval string
-    // if ((/\|/).test(msg) && (typeof count !== 'undefined')) {
     if ((/\|/).test(msg)) {
       msg = parsePluralInterval(msg, count);
     }

--- a/i18n.js
+++ b/i18n.js
@@ -807,7 +807,7 @@ module.exports = (function() {
       var matches = p.match(/^\s*([\(\)\[\]]+[\d,]+[\(\)\[\]]+)?\s*(.*)$/);
 
       // not the same as in combined condition
-      if (matches[1]) {
+      if (matches != null && matches[1]) {
         intervalRuleExists = true;
         if (matchInterval(count, matches[1]) === true) {
           returnPhrase = matches[2];

--- a/i18n.js
+++ b/i18n.js
@@ -544,6 +544,7 @@ module.exports = (function() {
   var postProcess = function(msg, namedValues, args, count) {
 
     // test for parsable interval string
+    // if ((/\|/).test(msg) && (typeof count !== 'undefined')) {
     if ((/\|/).test(msg)) {
       msg = parsePluralInterval(msg, count);
     }
@@ -800,19 +801,24 @@ module.exports = (function() {
   var parsePluralInterval = function(phrase, count) {
     var returnPhrase = phrase;
     var phrases = phrase.split(/\|/);
+    var intervalRuleExists = false;
 
     // some() breaks on 1st true
     phrases.some(function(p) {
-      var matches = p.match(/^\s*([\(\)\[\]\d,]+)?\s*(.*)$/);
+      var matches = p.match(/^\s*([\(\)\[\]]+[\d,]+[\(\)\[\]]+)?\s*(.*)$/);
 
       // not the same as in combined condition
       if (matches[1]) {
+        intervalRuleExists = true;
         if (matchInterval(count, matches[1]) === true) {
           returnPhrase = matches[2];
           return true;
         }
       } else {
-        returnPhrase = p;
+        // this is a other or catch all case, this only is taken into account if there is actually another rule
+        if (intervalRuleExists) {
+          returnPhrase = p;
+        }
       }
 
     });

--- a/locales/en.json
+++ b/locales/en.json
@@ -127,5 +127,6 @@
 	". is first character": "Dot is first character",
 	"last character is .": "last character is Dot",
 	"few sentences. with .": "few sentences with Dot",
-	"Hello {{{name}}}": "Hello {{{name}}}"
+	"Hello {{{name}}}": "Hello {{{name}}}",
+	"Standalone | 42 symbol somewhere | in the text | 1| 0": "Standalone | 42 symbol somewhere | in the text | 1| 0"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,5 +128,6 @@
 	"last character is .": "last character is Dot",
 	"few sentences. with .": "few sentences with Dot",
 	"Hello {{{name}}}": "Hello {{{name}}}",
-	"Standalone | 42 symbol somewhere | in the text | 1| 0": "Standalone | 42 symbol somewhere | in the text | 1| 0"
+	"Standalone | 42 symbol somewhere | in the text | 1| 0": "Standalone | 42 symbol somewhere | in the text | 1| 0",
+	"should ignore \n standalone | mixed with \n new lines 42 | value - 42": "should ignore \n standalone | mixed with \n new lines 42 | value - 42"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n",
   "description": "lightweight translation module with dynamic json storage",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "homepage": "http://github.com/mashpie/i18n-node",
   "repository": {
     "type": "git",

--- a/test/i18n.plurals.js
+++ b/test/i18n.plurals.js
@@ -23,6 +23,14 @@ describe('parsing plural intervals from strings', function() {
     );
   });
 
+  it('should ignore mixed pipe and newline symbols', function() {
+    const standalone = 'should ignore \n standalone | mixed with \n new lines 42 | value - 42';
+    should.equal(
+       pluralTest.__(standalone),
+       standalone
+    );
+  });
+
   it('should work with classic format too', function() {
     should.equal(
       "There are 3 monkeys in the tree",

--- a/test/i18n.plurals.js
+++ b/test/i18n.plurals.js
@@ -14,6 +14,15 @@ i18n.setLocale(pluralTest, 'en');
 
 describe('parsing plural intervals from strings', function() {
 
+  // ignoring pipe symbols without interval rules, see #274
+  it('should ignore standalone | symbols', function() {
+    const standalone = 'Standalone | 42 symbol somewhere | in the text | 1| 0';
+    should.equal(
+       pluralTest.__(standalone),
+       standalone
+    );
+  });
+
   it('should work with classic format too', function() {
     should.equal(
       "There are 3 monkeys in the tree",


### PR DESCRIPTION
We are happy users of your great library, but we encountered an issue with the pipe character. We wanted to use the pipe symbol directly as part of the text - without using the variable workaround as mentioned in [this stackoverflow question](https://stackoverflow.com/questions/38398415/how-to-escape-pipe-character-in-node-js-i18n-plugin#38643673). Thus this pull request is changing the parsing logic regarding to the pipe as following:

1. only an interval with starting and closing brackets is evaluated (limiting within the regex)
2. to treat a single pipe symbol as "otherwise" case, there must be already an interval specified before

Additionally I've pushed the version to 0.10.1. Existing tests ran without any changes, additionally I added two test cases to verify the changed standalone pipe symbol behavior.

This should fix #274 and could maybe superseed pull request #388 

If there is anything to add in the code or additionally to test I'm happy to do that. Thanks for the great library!