### PR TITLE
#437 - Move execution for IIFE to index.js

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -1213,4 +1213,4 @@ module.exports = (function() {
 
   return i18n;
 
-}());
+});

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./i18n');
+module.exports = require('./i18n')();

--- a/test/i18n.api.global.js
+++ b/test/i18n.api.global.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 describe('Module API', function() {

--- a/test/i18n.api.local.js
+++ b/test/i18n.api.local.js
@@ -1,7 +1,7 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
 // now with coverage suport
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should");
 
 describe('Module API', function () {

--- a/test/i18n.configure.js
+++ b/test/i18n.configure.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs');
 

--- a/test/i18n.configureApi.js
+++ b/test/i18n.configureApi.js
@@ -1,11 +1,11 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should"),
     fs = require('fs'),
     path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 
 function reconfigure(config) {

--- a/test/i18n.configureAutoreload.js
+++ b/test/i18n.configureAutoreload.js
@@ -1,9 +1,9 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 var timeout = 50;
 

--- a/test/i18n.configureCookiename.js
+++ b/test/i18n.configureCookiename.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.configureLocales.js
+++ b/test/i18n.configureLocales.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.configurePermissions.js
+++ b/test/i18n.configurePermissions.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path"),
   fs = require('fs');

--- a/test/i18n.configureQueryParameter.js
+++ b/test/i18n.configureQueryParameter.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.configureRegister.js
+++ b/test/i18n.configureRegister.js
@@ -1,11 +1,11 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should"),
     fs = require('fs'),
     path = require('path');
 
-var i18nPath = 'i18n';
+var i18nPath = 'index';
 var i18nFilename = path.resolve(i18nPath + '.js');
 
 function reconfigure(config) {

--- a/test/i18n.configureStaticCatalog.js
+++ b/test/i18n.configureStaticCatalog.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 describe('staticCatalog configuration', function() {

--- a/test/i18n.defaults.js
+++ b/test/i18n.defaults.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs');
 

--- a/test/i18n.fallbacks.js
+++ b/test/i18n.fallbacks.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 
@@ -94,7 +94,7 @@ describe('Fallbacks', function() {
   describe('Fallback to locale', function() {
     beforeEach(function() {
       // Force reloading of i18n, to reset configuration
-      var i18nPath = 'i18n';
+      var i18nPath = 'index';
       var i18nFilename = path.resolve(i18nPath + '.js');
       delete require.cache[i18nFilename];
       i18n = require(i18nFilename);
@@ -129,7 +129,7 @@ describe('Fallbacks', function() {
   describe('Keep valid locale', function() {
     beforeEach(function() {
       // Force reloading of i18n, to reset configuration
-      var i18nPath = 'i18n';
+      var i18nPath = 'index';
       var i18nFilename = path.resolve(i18nPath + '.js');
       delete require.cache[i18nFilename];
       i18n = require(i18nFilename);

--- a/test/i18n.init.js
+++ b/test/i18n.init.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   sinon = require("sinon"),
   fs = require('fs');

--- a/test/i18n.listsHashes.js
+++ b/test/i18n.listsHashes.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.makePlurals.js
+++ b/test/i18n.makePlurals.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.mf.js
+++ b/test/i18n.mf.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');

--- a/test/i18n.missingPhrases.js
+++ b/test/i18n.missingPhrases.js
@@ -1,7 +1,7 @@
 /*jslint nomen: true, undef: true, sloppy: true, white: true, stupid: true, passfail: false, node: true, plusplus: true, indent: 2 */
 
 // now with coverage suport
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     should = require("should");
 
 describe('Missing Phrases', function () {

--- a/test/i18n.objectnotation.js
+++ b/test/i18n.objectnotation.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n');
+var i18n = require('../index');
 var should = require("should");
 
 describe('Object Notation', function() {

--- a/test/i18n.plurals.js
+++ b/test/i18n.plurals.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 // reserve a "private" scope

--- a/test/i18n.setLocale.js
+++ b/test/i18n.setLocale.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.setLocaleDefaultLanguage.js
+++ b/test/i18n.setLocaleDefaultLanguage.js
@@ -4,7 +4,7 @@
  * req.setLocale("locale") sets defaultLanguage when req.locals is not defined #166
  *
  */
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   path = require("path");
 

--- a/test/i18n.setup.js
+++ b/test/i18n.setup.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
     pkgVersion = require('../package.json').version,
     should = require("should");
 

--- a/test/i18n.verifyLocaleSelectionMethods.js
+++ b/test/i18n.verifyLocaleSelectionMethods.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should");
 
 describe('when configuring selected locale', function () {

--- a/test/i18n.writenewPhrase.js
+++ b/test/i18n.writenewPhrase.js
@@ -1,4 +1,4 @@
-var i18n = require('../i18n'),
+var i18n = require('../index'),
   should = require("should"),
   fs = require('fs'),
   path = require('path');


### PR DESCRIPTION
By moving the execution of the IIFE to `index.js` it allows me to bypass the globally created instance of i18n in order to preserve the context between applications.

This change allows me to import i18n function like this

```javascript
const i18nFn = require('i18n/i18n');

const i18nInstance = new i18nFn();

i18nInstance.configure({});
```

Which is a solution for #437 

rather than 

```javascript
const i18n = require('i18n');

i18n.configure({});
```

So that the subsequent calls to `configure` do not overwrite the preceding calls to `configure`