### PR TITLE
Rename locals to locales

### DIFF
--- a/examples/express4-setLocale/index.js
+++ b/examples/express4-setLocale/index.js
@@ -4,7 +4,7 @@ var i18n = require('../../i18n');
 
 // another 'global' object that is bound to i18n additionaly
 // DANGER! this `funkyObject` is NOT concurrency aware,
-// while req, res and res.locals are and will always be
+// while req, res and res.locales are and will always be
 var funkyObject = {};
 
 i18n.configure({
@@ -17,48 +17,48 @@ var app = express();
 app.use(i18n.init);
 
 // uses locale as guessed by accept-headers
-// req: Hallo res: Hallo res.locals: Hallo funkyObject: Hallo
+// req: Hallo res: Hallo res.locales: Hallo funkyObject: Hallo
 app.get('/default/:lang', function(req, res) {
   render(req, res);
 });
 
 // implicitly sets all
-// req: مرحبا res: مرحبا res.locals: مرحبا funkyObject: مرحبا
+// req: مرحبا res: مرحبا res.locales: مرحبا funkyObject: مرحبا
 app.get('/onreq/:lang', function(req, res) {
   i18n.setLocale(req, req.params.lang);
   render(req, res);
 });
 
-// sets res, res.locals and funkyObject
-// req: Hallo res: مرحبا res.locals: مرحبا funkyObject: مرحبا
+// sets res, res.locales and funkyObject
+// req: Hallo res: مرحبا res.locales: مرحبا funkyObject: مرحبا
 app.get('/onres/:lang', function(req, res) {
   i18n.setLocale(res, req.params.lang);
   render(req, res);
 });
 
-// sets res.locals and funkyObject
-// req: Hallo res: Hallo res.locals: مرحبا funkyObject: مرحبا
-app.get('/onreslocals/:lang', function(req, res) {
-  i18n.setLocale(res.locals, req.params.lang);
+// sets res.locales and funkyObject
+// req: Hallo res: Hallo res.locales: مرحبا funkyObject: مرحبا
+app.get('/onreslocales/:lang', function(req, res) {
+  i18n.setLocale(res.locales, req.params.lang);
   render(req, res);
 });
 
 // sets funkyObject only
-// req: Hallo res: Hallo res.locals: Hallo funkyObject: مرحبا
+// req: Hallo res: Hallo res.locales: Hallo funkyObject: مرحبا
 app.get('/onfunky/:lang', function(req, res) {
   i18n.setLocale(funkyObject, req.params.lang);
   render(req, res);
 });
 
 // sets req & funkyObject only
-// req: مرحبا res: Hallo res.locals: Hallo funkyObject: مرحبا
+// req: مرحبا res: Hallo res.locales: Hallo funkyObject: مرحبا
 app.get('/onarray/:lang', function(req, res) {
   i18n.setLocale([req, funkyObject], req.params.lang);
   render(req, res);
 });
 
 // sets res & funkyObject only
-// req: Hallo res: مرحبا res.locals: Hallo funkyObject: مرحبا
+// req: Hallo res: مرحبا res.locales: Hallo funkyObject: مرحبا
 app.get('/onresonly/:lang', function(req, res) {
   i18n.setLocale(res, req.params.lang, true);
   render(req, res);
@@ -68,7 +68,7 @@ var getBody = function(req, res){
   var body = '';
   body += ' req: ' + req.__('Hello');
   body += ' res: ' + res.__('Hello');
-  body += ' res.locals: ' + res.locals.__('Hello');
+  body += ' res.locales: ' + res.locales.__('Hello');
   body += ' funkyObject: ' + funkyObject.__('Hello');
   return body;
 };

--- a/examples/express4-setLocale/test.js
+++ b/examples/express4-setLocale/test.js
@@ -11,7 +11,7 @@ var Browser = require('zombie'),
 describe('Using i18n in express 4.x with setLocale', function() {
 
   describe('res.send() is able to handle concurrent request correctly', function() {
-    var expected = 'req: Hallo res: Hallo res.locals: Hallo funkyObject: Hallo';
+    var expected = 'req: Hallo res: Hallo res.locales: Hallo funkyObject: Hallo';
     var url = 'default';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
@@ -22,7 +22,7 @@ describe('Using i18n in express 4.x with setLocale', function() {
   });
 
   describe('i18n.setLocale(req, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: مرحبا res: مرحبا res.locals: مرحبا funkyObject: مرحبا';
+    var expected = 'req: مرحبا res: مرحبا res.locales: مرحبا funkyObject: مرحبا';
     var url = 'onreq';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
@@ -33,7 +33,7 @@ describe('Using i18n in express 4.x with setLocale', function() {
   });
 
   describe('i18n.setLocale(res, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: Hallo res: مرحبا res.locals: مرحبا funkyObject: مرحبا';
+    var expected = 'req: Hallo res: مرحبا res.locales: مرحبا funkyObject: مرحبا';
     var url = 'onres';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
@@ -43,9 +43,9 @@ describe('Using i18n in express 4.x with setLocale', function() {
     });
   });
 
-  describe('i18n.setLocale(res.locals, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: Hallo res: Hallo res.locals: مرحبا funkyObject: مرحبا';
-    var url = 'onreslocals';
+  describe('i18n.setLocale(res.locales, req.params.lang) is able to set locales correctly by param', function() {
+    var expected = 'req: Hallo res: Hallo res.locales: مرحبا funkyObject: مرحبا';
+    var url = 'onreslocales';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
     });
@@ -54,8 +54,8 @@ describe('Using i18n in express 4.x with setLocale', function() {
     });
   });
 
-  describe('i18n.setLocale(res.locals, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: Hallo res: Hallo res.locals: Hallo funkyObject: مرحبا';
+  describe('i18n.setLocale(res.locales, req.params.lang) is able to set locales correctly by param', function() {
+    var expected = 'req: Hallo res: Hallo res.locales: Hallo funkyObject: مرحبا';
     var url = 'onfunky';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
@@ -65,8 +65,8 @@ describe('Using i18n in express 4.x with setLocale', function() {
     });
   });
 
-  describe('i18n.setLocale(res.locals, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: مرحبا res: Hallo res.locals: Hallo funkyObject: مرحبا';
+  describe('i18n.setLocale(res.locales, req.params.lang) is able to set locales correctly by param', function() {
+    var expected = 'req: مرحبا res: Hallo res.locales: Hallo funkyObject: مرحبا';
     var url = 'onarray';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);
@@ -76,8 +76,8 @@ describe('Using i18n in express 4.x with setLocale', function() {
     });
   });
 
-  describe('i18n.setLocale(res.locals, req.params.lang) is able to set locales correctly by param', function() {
-    var expected = 'req: Hallo res: مرحبا res.locals: Hallo funkyObject: مرحبا';
+  describe('i18n.setLocale(res.locales, req.params.lang) is able to set locales correctly by param', function() {
+    var expected = 'req: Hallo res: مرحبا res.locales: Hallo funkyObject: مرحبا';
     var url = 'onresonly';
     describe('serial requests', function() {
       visitLinks('series', url + '/ar', DE, expected, DE, expected);

--- a/i18n.js
+++ b/i18n.js
@@ -441,25 +441,25 @@ module.exports = (function() {
       // escape recursion
       // @see  - https://github.com/balderdashy/sails/pull/3631
       //       - https://github.com/mashpie/i18n-node/pull/218
-      if (targetObject.res.locals) {
+      if (targetObject.res.locales) {
         i18n.setLocale(targetObject.res, targetObject.locale, true);
-        i18n.setLocale(targetObject.res.locals, targetObject.locale, true);
+        i18n.setLocale(targetObject.res.locales, targetObject.locale, true);
       } else {
         i18n.setLocale(targetObject.res, targetObject.locale);
       }
     }
 
-    // consider locals
-    if (targetObject.locals && !skipImplicitObjects) {
+    // consider locales
+    if (targetObject.locales && !skipImplicitObjects) {
 
       // escape recursion
       // @see  - https://github.com/balderdashy/sails/pull/3631
       //       - https://github.com/mashpie/i18n-node/pull/218
-      if (targetObject.locals.res) {
-        i18n.setLocale(targetObject.locals, targetObject.locale, true);
-        i18n.setLocale(targetObject.locals.res, targetObject.locale, true);
+      if (targetObject.locales.res) {
+        i18n.setLocale(targetObject.locales, targetObject.locale, true);
+        i18n.setLocale(targetObject.locales.res, targetObject.locale, true);
       } else {
-        i18n.setLocale(targetObject.locals, targetObject.locale);
+        i18n.setLocale(targetObject.locales, targetObject.locale);
       }
     }
 
@@ -622,9 +622,9 @@ module.exports = (function() {
       applyAPItoObject(object.res);
     }
 
-    // attach to locals if present (ie. in express)
-    if (object.locals) {
-      applyAPItoObject(object.locals);
+    // attach to locales if present (ie. in express)
+    if (object.locales) {
+      applyAPItoObject(object.locales);
     }
   };
 

--- a/test/i18n.configureApi.js
+++ b/test/i18n.configureApi.js
@@ -69,9 +69,9 @@ describe('configure api', function() {
         should.equal(typeof customObject.__, 'undefined');
     });
 
-    it('should escape res -> locals -> res recursion', function() {
+    it('should escape res -> locales -> res recursion', function() {
         var customObject = {};
-        customObject.locals = { res: customObject };
+        customObject.locales = { res: customObject };
         reconfigure({
             locales: ['en', 'de'],
             register: customObject,
@@ -80,6 +80,6 @@ describe('configure api', function() {
             }
         });
         should.equal(typeof customObject.t, 'function');
-        should.equal(typeof customObject.locals.t, 'function');
+        should.equal(typeof customObject.locales.t, 'function');
     });
 });

--- a/test/i18n.configureCookiename.js
+++ b/test/i18n.configureCookiename.js
@@ -28,7 +28,7 @@ describe('Locale switching should work when set via cookie', function() {
     };
 
     res = {
-      locals: {}
+      locales: {}
     };
   });
 
@@ -40,10 +40,10 @@ describe('Locale switching should work when set via cookie', function() {
 
     req.getLocale().should.equal('fr');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Bonjour');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 });

--- a/test/i18n.configureQueryParameter.js
+++ b/test/i18n.configureQueryParameter.js
@@ -29,7 +29,7 @@ describe('Locale switching should work queryParameter', function() {
     };
 
     res = {
-      locals: {}
+      locales: {}
     };
   });
 
@@ -41,11 +41,11 @@ describe('Locale switching should work queryParameter', function() {
 
     req.getLocale().should.equal('fr');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Bonjour');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
   it('should support WHATWG URL API', function() {

--- a/test/i18n.setLocale.js
+++ b/test/i18n.setLocale.js
@@ -128,9 +128,9 @@ describe('Locale switching should work on req and res', function() {
     res.__('Hello').should.equal('Bonjour');
   });
 
-  it('setLocale() should switch locale for req, res and res.locals implicitly', function() {
-    // add locals to res
-    res.locals = {};
+  it('setLocale() should switch locale for req, res and res.locales implicitly', function() {
+    // add locales to res
+    res.locales = {};
 
     // add res to req to simulate express 4.x schema
     req.res = res;
@@ -139,20 +139,20 @@ describe('Locale switching should work on req and res', function() {
 
     i18n.getLocale(req).should.equal('fr');
     i18n.getLocale(res).should.equal('fr');
-    i18n.getLocale(res.locals).should.equal('fr');
+    i18n.getLocale(res.locales).should.equal('fr');
 
     req.getLocale().should.equal('fr');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Bonjour');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
-  it('setLocale() should switch locale for req, res and res.locals implicitly when set on req', function() {
-    // add locals to res
-    res.locals = {};
+  it('setLocale() should switch locale for req, res and res.locales implicitly when set on req', function() {
+    // add locales to res
+    res.locales = {};
 
     // add res to req to simulate express 4.x schema
     req.res = res;
@@ -161,20 +161,20 @@ describe('Locale switching should work on req and res', function() {
 
     i18n.getLocale(req).should.equal('fr');
     i18n.getLocale(res).should.equal('fr');
-    i18n.getLocale(res.locals).should.equal('fr');
+    i18n.getLocale(res.locales).should.equal('fr');
 
     req.getLocale().should.equal('fr');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Bonjour');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
-  it('setLocale() should switch locale for req, res and res.locals implicitly when set on res', function() {
-    // add locals to res
-    res.locals = {};
+  it('setLocale() should switch locale for req, res and res.locales implicitly when set on res', function() {
+    // add locales to res
+    res.locales = {};
 
     // add res to req to simulate express 4.x schema
     req.res = res;
@@ -183,66 +183,66 @@ describe('Locale switching should work on req and res', function() {
 
     i18n.getLocale(req).should.equal('de');
     i18n.getLocale(res).should.equal('fr');
-    i18n.getLocale(res.locals).should.equal('fr');
+    i18n.getLocale(res.locales).should.equal('fr');
 
     req.getLocale().should.equal('de');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Hallo');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
-  it('setLocale() should switch locale for req, res and res.locals implicitly when set on res.locals', function() {
-    // add locals to res
-    res.locals = {};
+  it('setLocale() should switch locale for req, res and res.locales implicitly when set on res.locales', function() {
+    // add locales to res
+    res.locales = {};
 
     // add res to req to simulate express 4.x schema
     req.res = res;
     i18n.init(req, res);
-    res.locals.setLocale('fr');
+    res.locales.setLocale('fr');
 
     i18n.getLocale(req).should.equal('de');
     i18n.getLocale(res).should.equal('de');
-    i18n.getLocale(res.locals).should.equal('fr');
+    i18n.getLocale(res.locales).should.equal('fr');
 
     req.getLocale().should.equal('de');
     res.getLocale().should.equal('de');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Hallo');
     res.__('Hello').should.equal('Hallo');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
 
-  it('setLocale() should switch locale for req, res and res.locals implicitly when set as array', function() {
-    // add locals to res
-    res.locals = {};
+  it('setLocale() should switch locale for req, res and res.locales implicitly when set as array', function() {
+    // add locales to res
+    res.locales = {};
 
     // add res to req to simulate express 4.x schema
     req.res = res;
     i18n.init(req, res);
-    i18n.setLocale([req, res, res.locals], 'fr');
+    i18n.setLocale([req, res, res.locales], 'fr');
 
     i18n.getLocale(req).should.equal('fr');
     i18n.getLocale(res).should.equal('fr');
-    i18n.getLocale(res.locals).should.equal('fr');
+    i18n.getLocale(res.locales).should.equal('fr');
 
     req.getLocale().should.equal('fr');
     res.getLocale().should.equal('fr');
-    res.locals.getLocale().should.equal('fr');
+    res.locales.getLocale().should.equal('fr');
 
     req.__('Hello').should.equal('Bonjour');
     res.__('Hello').should.equal('Bonjour');
-    res.locals.__('Hello').should.equal('Bonjour');
+    res.locales.__('Hello').should.equal('Bonjour');
   });
 
 
-  it('setLocale(object) should escape res -> locals -> res recursion', function() {
-    // add locals to res
-    res.locals = { res: res };
+  it('setLocale(object) should escape res -> locales -> res recursion', function() {
+    // add locales to res
+    res.locales = { res: res };
 
     // add res to req to simulate express 4.x schema
     req.res = res;
@@ -250,7 +250,7 @@ describe('Locale switching should work on req and res', function() {
     i18n.setLocale(req, 'fr');
 
     res.locale.should.equal('fr');
-    res.locals.locale.should.equal('fr');
+    res.locales.locale.should.equal('fr');
   });
 
 });

--- a/test/i18n.setLocaleDefaultLanguage.js
+++ b/test/i18n.setLocaleDefaultLanguage.js
@@ -1,7 +1,7 @@
 /**
  * regression test to cover
  *
- * req.setLocale("locale") sets defaultLanguage when req.locals is not defined #166
+ * req.setLocale("locale") sets defaultLanguage when req.locales is not defined #166
  *
  */
 var i18n = require('../i18n'),

--- a/test/i18n.verifyLocaleSelectionMethods.js
+++ b/test/i18n.verifyLocaleSelectionMethods.js
@@ -39,7 +39,7 @@ describe('when configuring selected locale', function () {
   };
 
   beforeEach(function () {
-    res = { locals: {} };
+    res = { locales: {} };
     i18n.configure({
       locales: ['de-AT', 'de-DE', 'en-GB', 'tr-TR', 'en-US', 'en'],
       defaultLocale: 'default-locale',


### PR DESCRIPTION
Possible solution to 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46328#issuecomment-663790163
https://github.com/mashpie/i18n-node/issues/440

`@types/i18n` would need to be so that 

```typescript
declare namespace Express {
    interface Request extends i18nAPI {
        languages: string[];
        regions: string[];
        language: string;
        region: string;
    }

    interface Response extends i18nAPI {
        locales: i18nAPI;
    }
}
```

in order to prevent conflict

Alternatively we can just remove strict type in `@types/i18n` for `locals`
```typescript
declare namespace Express {
    interface Request extends i18nAPI {
        languages: string[];
        regions: string[];
        language: string;
        region: string;
    }

    interface Response extends i18nAPI {
        locals: any;
    }
}
```

I don't see how that helps with applications that want to be strongly typed but its a possible solution.