### PR TITLE
Default to 1st non-empty language query parameter

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -658,6 +658,28 @@ module.exports = (function() {
   };
 
   /**
+   * @param queryLanguage - language query parameter, either an array or a string.
+   * @return the first non-empty language query parameter found, null otherwise.
+   */
+  function extractQueryLanguage(queryLanguage) {
+    let language = null
+
+    if (Array.isArray(queryLanguage)) {
+      for (let i = 0; i < queryLanguage.length; ++i) {
+        if (queryLanguage[i] && (queryLanguage[i] !== "")) {
+          language = queryLanguage[i]
+          break
+        }
+      }
+    } else if (queryLanguage !== "") {
+      language = queryLanguage
+    }
+
+    return language
+  }
+
+
+  /**
    * guess language setting based on http headers
    */
 
@@ -676,15 +698,16 @@ module.exports = (function() {
       if (queryParameter && request.url) {
         var urlAsString = typeof request.url === 'string' ? request.url : request.url.toString();
         var urlObj = url.parse(urlAsString, true);
-        if (urlObj.query[queryParameter]) {
-          logDebug('Overriding locale from query: ' + urlObj.query[queryParameter]);
-          request.language = urlObj.query[queryParameter];
+        var languageQueryParameter = urlObj.query[queryParameter];
+        if (languageQueryParameter) {
+          logDebug('Overriding locale from query: ' + languageQueryParameter);
+          let queryLanguage = extractQueryLanguage(languageQueryParameter);
 
-          if (preserveLegacyCase) {
-            request.language = request.language.toLowerCase();
+          if (queryLanguage && preserveLegacyCase) {
+            queryLanguage = queryLanguage.toLowerCase();
           }
 
-          return i18n.setLocale(request, request.language);
+          return i18n.setLocale(request, queryLanguage);
         }
       }
 

--- a/i18n.js
+++ b/i18n.js
@@ -662,20 +662,20 @@ module.exports = (function() {
    * @return the first non-empty language query parameter found, null otherwise.
    */
   function extractQueryLanguage(queryLanguage) {
-    let language = null
+    let language = null;
 
     if (Array.isArray(queryLanguage)) {
       for (let i = 0; i < queryLanguage.length; ++i) {
-        if (queryLanguage[i] && (queryLanguage[i] !== "")) {
-          language = queryLanguage[i]
-          break
+        if (queryLanguage[i] && (queryLanguage[i] !== '')) {
+          language = queryLanguage[i];
+          break;
         }
       }
-    } else if (queryLanguage !== "") {
-      language = queryLanguage
+    } else if (queryLanguage !== '') {
+      language = queryLanguage;
     }
 
-    return language
+    return language;
   }
 
 

--- a/test/i18n.configureQueryParameter.js
+++ b/test/i18n.configureQueryParameter.js
@@ -54,4 +54,22 @@ describe('Locale switching should work queryParameter', function() {
     i18n.getLocale(req).should.equal('fr');
     i18n.getLocale(res).should.equal('fr');
   });
+
+  it('should handle multiple query parameters', function() {
+    const uriPath = '/test?lang=de&lang=fr';
+    req.request = `GET ${uriPath}`;
+    req.url = new URL(uriPath, 'http://localhost');
+    i18n.init(req, res);
+    i18n.getLocale(req).should.equal('de');
+    i18n.getLocale(res).should.equal('de');
+  });
+
+  it('should handle multiple query parameters, first is empty', function() {
+    const uriPath = '/test?lang=&lang=de';
+    req.request = `GET ${uriPath}`;
+    req.url = new URL(uriPath, 'http://localhost');
+    i18n.init(req, res);
+    i18n.getLocale(req).should.equal('de');
+    i18n.getLocale(res).should.equal('de');
+  });
 });


### PR DESCRIPTION
Do not throw an exception if there are multiple "language" query parameters and the first is empty.
Instead use the the first non-empty query parameter.
This is an extension of the following fix:
https://github.com/mashpie/i18n-node/pull/380