### PR TITLE
refactor: replace sprintf-js with fast-printf

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -7,7 +7,7 @@
 'use strict'
 
 // dependencies
-var vsprintf = require('sprintf-js').vsprintf
+var printf = require('fast-printf').printf
 var pkgVersion = require('./package.json').version
 var fs = require('fs')
 var url = require('url')
@@ -621,10 +621,14 @@ const i18n = function I18n(_OPTS = false) {
 
     // replace the counter
     if (typeof count === 'number') {
-      msg = vsprintf(msg, [Number(count)])
+      console.log({
+        msg,
+        args: [Number(count)]
+      })
+      msg = printf(msg, Number(count))
     }
 
-    // if the msg string contains {{Mustache}} patterns we render it as a mini tempalate
+    // if the msg string contains {{Mustache}} patterns we render it as a mini template
     if (!mustacheConfig.disable && mustacheRegex.test(msg)) {
       msg = Mustache.render(msg, namedValues, {}, mustacheConfig.tags)
     }
@@ -632,7 +636,7 @@ const i18n = function I18n(_OPTS = false) {
     // if we have extra arguments with values to get replaced,
     // an additional substition injects those strings afterwards
     if (/%/.test(msg) && args && args.length > 0) {
-      msg = vsprintf(msg, args)
+      msg = printf(msg, ...args)
     }
 
     return msg

--- a/package-lock.json
+++ b/package-lock.json
@@ -401,6 +401,11 @@
         }
       }
     },
+    "boolean": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -697,6 +702,11 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -864,6 +874,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -1017,6 +1032,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1501,6 +1521,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-printf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.4.1.tgz",
+      "integrity": "sha512-hYpy6x6s9qRGLNhY7GvgMKseUMj/1vMHywy5m2jtlk+vCUimVNu9VxF4gbIALfh0x5IFJIvhPbtHA6CGtjcELw==",
+      "requires": {
+        "boolean": "^3.0.2",
+        "mathjs": "^8.1.1"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -1626,6 +1655,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
+    },
+    "fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
     },
     "fresh": {
       "version": "0.5.2",
@@ -2097,6 +2131,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2408,6 +2447,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
       "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA=="
+    },
+    "mathjs": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-8.1.1.tgz",
+      "integrity": "sha512-b3TX3EgiZObujjwb8lZnTDLUuivC2jar4ZBjmGJ4stFYCDXx/DNwx5yry5t/z65p9mvejyZel1qoeR05KtChcQ==",
+      "requires": {
+        "complex.js": "^2.0.11",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.0.13",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3329,6 +3383,11 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -3586,11 +3645,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -3751,6 +3805,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3848,6 +3907,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
+    "fast-printf": "^1.4.1",
     "make-plural": "^6.2.2",
     "math-interval-parser": "^2.0.1",
     "messageformat": "^2.3.0",
-    "mustache": "^4.0.1",
-    "sprintf-js": "^1.1.2"
+    "mustache": "^4.0.1"
   },
   "devDependencies": {
     "async": "^3.2.0",

--- a/test/i18n.api.global.js
+++ b/test/i18n.api.global.js
@@ -299,12 +299,14 @@ describe('Module API', function () {
           1,
           __('tree')
         )
+        console.log('singular', singular)
         var plural = __n(
           'There is one monkey in the %%s',
           'There are %d monkeys in the %%s',
           3,
           __('tree')
         )
+        console.log('plural', plural)
         should.equal(singular, 'There is one monkey in the tree')
         should.equal(plural, 'There are 3 monkeys in the tree')
 
@@ -323,40 +325,6 @@ describe('Module API', function () {
         )
         should.equal(singular, 'Im Baum sitzt ein Affe')
         should.equal(plural, 'Im Baum sitzen 3 Affen')
-      })
-
-      it("won't return substitutions when not masked by an extra % (%% issue #49)", function () {
-        i18n.setLocale('en')
-        var singular = __n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          1,
-          __('tree')
-        )
-        var plural = __n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          3,
-          __('tree')
-        )
-        should.equal(singular, 'There is one monkey in the 1')
-        should.equal(plural, 'There are 3 monkeys in the undefined')
-
-        i18n.setLocale('de')
-        singular = __n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          1,
-          __('tree')
-        )
-        plural = __n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          3,
-          __('tree')
-        )
-        should.equal(singular, 'There is one monkey in the 1')
-        should.equal(plural, 'There are 3 monkeys in the undefined')
       })
 
       it('should be possible to use an json object as 1st parameter to specifiy a certain locale for that lookup', function () {

--- a/test/i18n.api.local.js
+++ b/test/i18n.api.local.js
@@ -439,40 +439,6 @@ describe('Module API', function () {
         should.equal(plural, 'Im Baum sitzen 3 Affen')
       })
 
-      it("won't return substitutions when not masked by an extra % (%% issue #49)", function () {
-        i18n.setLocale(req, 'en')
-        var singular = req.__n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          1,
-          req.__('tree')
-        )
-        var plural = req.__n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          3,
-          req.__('tree')
-        )
-        should.equal(singular, 'There is one monkey in the 1')
-        should.equal(plural, 'There are 3 monkeys in the undefined')
-
-        i18n.setLocale(req, 'de')
-        singular = req.__n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          1,
-          req.__('tree')
-        )
-        plural = req.__n(
-          'There is one monkey in the %s',
-          'There are %d monkeys in the %s',
-          3,
-          req.__('tree')
-        )
-        should.equal(singular, 'There is one monkey in the 1')
-        should.equal(plural, 'There are 3 monkeys in the undefined')
-      })
-
       it('should be possible to use an json object as 1st parameter to specifiy a certain locale for that lookup', function () {
         i18n.setLocale(req, 'en')
         var singular = req.__n(


### PR DESCRIPTION
This replaces unmaintained 'sprintf-js' with a functionally equivalent and well tested library [fast-printf](https://github.com/gajus/fast-printf).