### PR TITLE
Use translation from default locale if provided locale is `undefined` or `null`

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -273,10 +273,9 @@ const i18n = function I18n(_OPTS = false) {
     // called like __({phrase: "Hello", locale: "en"})
     if (typeof phrase === 'object') {
       if (
-        typeof phrase.locale === 'string' &&
         typeof phrase.phrase === 'string'
       ) {
-        msg = translate(phrase.locale, phrase.phrase)
+        msg = translate(getLocaleFromObject(phrase), phrase.phrase)
       }
     }
     // called like __("Hello")

--- a/test/i18n.retryInDefaultLocale.js
+++ b/test/i18n.retryInDefaultLocale.js
@@ -31,6 +31,10 @@ describe('retryInDefaultLocale', () => {
       should.equal(i18nWithDefault.__('greeting.formal'), 'Hello')
     })
 
+    it('should use translations from defaultLocale if provided locale is "undefined"', () => {
+      should.equal(i18nWithDefault.__({ phrase: 'greeting.formal', locale: undefined }), 'Hello')
+    })
+
     it('should default "en" when locale is set to unconfigured value', () => {
       i18nWithDefault.setLocale('sv')
       should.equal(i18nWithDefault.getLocale(), 'en')
@@ -64,6 +68,10 @@ describe('retryInDefaultLocale', () => {
       i18nNoDefault.setLocale('en')
       should.equal(i18nNoDefault.getLocale(), 'en')
       should.equal(i18nNoDefault.__('greeting.formal'), 'Hello')
+    })
+
+    it('should use translation from defaultValue if provided locale is "undefined"', () => {
+      should.equal(i18nWithDefault.__({ phrase: 'greeting.formal', locale: undefined }), 'Hello')
     })
 
     it('should default "en" when locale is set to unconfigured value', () => {


### PR DESCRIPTION
Close #501.

- [x] Update singular translation API `i18n.__`
- [ ] Update plural translation API `i18n.__n`