### PR TITLE
Support per-call defaultValue for missing translations

### DIFF
--- a/test/default-value.test.js
+++ b/test/default-value.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+
+
+const fs = require('fs');
+
+const path = require('path');
+
+const os = require('os');
+
+const t = require('tap');
+
+const i18n = require('..');
+
+
+
+function tmpDir() {
+
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'i18n-node-'));
+
+}
+
+
+
+function readJSON(file) {
+
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+
+}
+
+
+
+t.test('defaultValue is returned when key is missing', (t) => {
+
+  const dir = tmpDir();
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: false,
+
+    objectNotation: false
+
+  });
+
+
+
+  const res = i18n.__('missing_key', { defaultValue: 'default_value' });
+
+  t.equal(res, 'default_value', 'returns provided defaultValue');
+
+  t.end();
+
+});
+
+
+
+t.test('defaultValue is persisted when updateFiles is true', (t) => {
+
+  const dir = tmpDir();
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: true,
+
+    objectNotation: false
+
+  });
+
+
+
+  const file = path.join(dir, 'en.json');
+
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+
+
+
+  const key = 'hello';
+
+  const def = 'default_value';
+
+  const res = i18n.__(key, { defaultValue: def });
+
+  t.equal(res, def, 'returns defaultValue');
+
+
+
+  // File should be written immediately by current implementation
+
+  t.equal(fs.existsSync(file), true, 'en.json is written');
+
+  const data = readJSON(file);
+
+  t.same(data[key], def, 'defaultValue persisted to file for missing key');
+
+  t.end();
+
+});
+
+
+
+t.test('existing keys ignore defaultValue and return stored translation', (t) => {
+
+  const dir = tmpDir();
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: true
+
+  });
+
+
+
+  const file = path.join(dir, 'en.json');
+
+  fs.writeFileSync(file, JSON.stringify({ greeting: 'Hola' }, null, 2));
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: true
+
+  });
+
+
+
+  const res = i18n.__('greeting', { defaultValue: 'Hello' });
+
+  t.equal(res, 'Hola', 'uses stored translation, not defaultValue');
+
+  t.end();
+
+});
+
+
+
+t.test('without defaultValue, missingKeyFn/key continues to be used', (t) => {
+
+  const dir = tmpDir();
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: false
+
+  });
+
+
+
+  const res = i18n.__('missing_key_2');
+
+  t.equal(res, 'missing_key_2', 'falls back to key by default');
+
+  t.end();
+
+});
+
+
+
+t.test('empty string translation is not treated as missing', (t) => {
+
+  const dir = tmpDir();
+
+  const file = path.join(dir, 'en.json');
+
+  fs.mkdirSync(dir, { recursive: true });
+
+  fs.writeFileSync(file, JSON.stringify({ empty: '' }, null, 2));
+
+
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: true
+
+  });
+
+
+
+  const res = i18n.__('empty', { defaultValue: 'fallback' });
+
+  t.equal(res, '', 'returns empty string, not defaultValue');
+
+  t.end();
+
+});
+
+
+
+t.test('objectNotation nested key defaultValue', (t) => {
+
+  const dir = tmpDir();
+
+  i18n.configure({
+
+    locales: ['en'],
+
+    directory: dir,
+
+    updateFiles: true,
+
+    objectNotation: true
+
+  });
+
+
+
+  const res = i18n.__('greet.morning', { defaultValue: 'Good morning' });
+
+  t.equal(res, 'Good morning', 'uses defaultValue for missing nested key');
+
+  const file = path.join(dir, 'en.json');
+
+  const data = readJSON(file);
+
+  t.equal(data['greet.morning'], 'Good morning', 'persists default for nested key path');
+
+  t.end();
+
+});


### PR DESCRIPTION
# PR Review: Support per-call defaultValue for missing translations

## Summary
- The feature addresses a real need: supplying a per-call default when a translation key is missing, and optionally persisting it when updateFiles is enabled.
- However, the patch includes broader refactors (write queue, async writes) that are unrelated to the feature and could cause regressions.
- Test location (tests/) likely won’t be picked up by the repo’s tap setup, and there are a few minor API/implementation nits.

## Key Findings
- Test path: The repository typically uses tap and expects tests under test/. Placing tests in tests/ may prevent them from running via npm test.
- Behavioral scope: Introducing write queues and process.nextTick-based writes changes existing behavior (e.g., immediate writeFile calls when updateFiles=true), potentially affecting users relying on synchronous write semantics or syncFiles.
- Diff applicability: Provided unified diffs are unlikely to apply cleanly without verifying exact line numbers and contexts from the current i18n.js. The changes also appear larger than necessary for the feature.
- API changes: An unused callOptions parameter was added to translate, and api.__ was re-wrapped without functional necessity.
- Tests: Good coverage for the defaultValue happy path and persistence. Missing edge tests (e.g., empty-string translations, objectNotation). Also, the planner’s third test expectation (undefined) contradicts the library’s current behavior (default is to return the key); your tests correctly reflect library behavior, but the plan/documentation should be updated accordingly.

## Recommendations (Concrete Fixes)
- Minimize changes to i18n.js:
  - Parse defaultValue from the last argument if it’s an object containing defaultValue.
  - When translation is missing (strictly undefined or null), use defaultValue if provided; otherwise, options.missingKeyFn.
  - If updateFiles=true, persist defaultValue (if provided) or missingKeyFn output immediately with the existing writeFile(locale) behavior. Avoid adding write queues and nextTick logic.
  - Do not introduce unused parameters; keep api.__ as-is.
- Test placement and coverage:
  - Move the new test file into test/ (e.g., test/default-value.test.js) so tap runs it.
  - Add tests for: empty-string translations (should not be treated as missing), and objectNotation/nested keys with defaultValue.
- Documentation:
  - Retain your new README section but explicitly state: defaultValue is only used when the key is missing (undefined/null), will be persisted when updateFiles=true, and empty strings are considered existing translations.

## Code Changes
### New file: test/default-value.test.js
```diff
--- /dev/null
+++ b/test/default-value.test.js
@@ -0,0 +1,168 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const t = require('tap');
+const i18n = require('..');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'i18n-node-'));
+}
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+t.test('defaultValue is returned when key is missing', (t) => {
+  const dir = tmpDir();
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: false,
+    objectNotation: false
+  });
+
+  const res = i18n.__('missing_key', { defaultValue: 'default_value' });
+  t.equal(res, 'default_value', 'returns provided defaultValue');
+  t.end();
+});
+
+t.test('defaultValue is persisted when updateFiles is true', (t) => {
+  const dir = tmpDir();
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: true,
+    objectNotation: false
+  });
+
+  const file = path.join(dir, 'en.json');
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+
+  const key = 'hello';
+  const def = 'default_value';
+  const res = i18n.__(key, { defaultValue: def });
+  t.equal(res, def, 'returns defaultValue');
+
+  // File should be written immediately by current implementation
+  t.equal(fs.existsSync(file), true, 'en.json is written');
+  const data = readJSON(file);
+  t.same(data[key], def, 'defaultValue persisted to file for missing key');
+  t.end();
+});
+
+t.test('existing keys ignore defaultValue and return stored translation', (t) => {
+  const dir = tmpDir();
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: true
+  });
+
+  const file = path.join(dir, 'en.json');
+  fs.writeFileSync(file, JSON.stringify({ greeting: 'Hola' }, null, 2));
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: true
+  });
+
+  const res = i18n.__('greeting', { defaultValue: 'Hello' });
+  t.equal(res, 'Hola', 'uses stored translation, not defaultValue');
+  t.end();
+});
+
+t.test('without defaultValue, missingKeyFn/key continues to be used', (t) => {
+  const dir = tmpDir();
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: false
+  });
+
+  const res = i18n.__('missing_key_2');
+  t.equal(res, 'missing_key_2', 'falls back to key by default');
+  t.end();
+});
+
+t.test('empty string translation is not treated as missing', (t) => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'en.json');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ empty: '' }, null, 2));
+
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: true
+  });
+
+  const res = i18n.__('empty', { defaultValue: 'fallback' });
+  t.equal(res, '', 'returns empty string, not defaultValue');
+  t.end();
+});
+
+t.test('objectNotation nested key defaultValue', (t) => {
+  const dir = tmpDir();
+  i18n.configure({
+    locales: ['en'],
+    directory: dir,
+    updateFiles: true,
+    objectNotation: true
+  });
+
+  const res = i18n.__('greet.morning', { defaultValue: 'Good morning' });
+  t.equal(res, 'Good morning', 'uses defaultValue for missing nested key');
+  const file = path.join(dir, 'en.json');
+  const data = readJSON(file);
+  t.equal(data['greet.morning'], 'Good morning', 'persists default for nested key path');
+  t.end();
+});
```

## Usage Examples
- Per-call default when a key is missing:
  - i18n.__('hello', { defaultValue: 'default_value' }) // returns 'default_value' if 'hello' is missing, and writes it when updateFiles is true
- With sprintf-style interpolation arguments:
  - i18n.__('greet %s', 'Jane', { defaultValue: 'Hi there!' }) // returns 'Hi there!' if 'greet %s' is missing; defaultValue is not interpolated
- Object form with locale override:
  - i18n.__({ phrase: 'tagline', locale: 'en' }, { defaultValue: 'The default tagline' })

How to Test:
1. npm install
2. Run tests: npm test
3. Manually verify persistence:
   - Configure i18n with updateFiles: true and a temporary directory.
   - Call i18n.__('missing_key', { defaultValue: 'default_value' }).
   - Check the locale file for the stored default.

## Conclusion
- The feature is valuable and aligns with user needs, but the current patch introduces broader changes and test placement issues that should be corrected before merging.
- Apply minimal, focused changes to i18n.js to support defaultValue without altering write semantics, move tests to test/, add a couple of edge tests, and refine README accordingly.