### PR TITLE
Don’t post-process the `MessageFormat` output in `__mf`

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -304,7 +304,8 @@ const i18n = function I18n(_OPTS = false) {
     let targetLocale = defaultLocale
     const argv = parseArgv(arguments)
     const namedValues = argv[0]
-    const args = argv[1]
+    if (argv[1].length > 0)
+      logWarn('i18n.__mf must be called with named values only')
 
     // called like __({phrase: "Hello", locale: "en"})
     if (typeof phrase === 'object') {
@@ -345,7 +346,7 @@ const i18n = function I18n(_OPTS = false) {
       mf.compiledFunctions[msg] = f
     }
 
-    return postProcess(f(namedValues), namedValues, args)
+    return f(namedValues)
   }
 
   i18n.__l = function i18nTranslationList(phrase) {

--- a/test/i18n.mf.js
+++ b/test/i18n.mf.js
@@ -21,10 +21,6 @@ describe('parsing Messageformat phrases', () => {
     mfTest.setLocale('de')
     should.equal('Hallo', mfTest.__mf('Hello'))
     should.equal('Hallo', mfTest.__mf('Hello'))
-    should.equal(
-      'Hallo Marcus, wie geht es dir heute?',
-      mfTest.__mf('Hello %s, how are you today?', 'Marcus')
-    )
     should.equal('Hello', i18n.__mf({ phrase: 'Hello', locale: 'en' }))
     should.equal('Hello', mfTest.__mf({ phrase: 'Hello', locale: 'en' }))
   })
@@ -37,14 +33,9 @@ describe('parsing Messageformat phrases', () => {
     )
 
     mfTest.setLocale('de')
-    should.equal(
-      'Hallo Marcus',
-      mfTest.__mf('Hello {name}', { name: 'Marcus' })
-    )
-    should.equal(
-      'Hallo Marcus, wie war dein test?',
-      mfTest.__mf('Hello {name}, how was your %s?', 'test', { name: 'Marcus' })
-    )
+    for (const name of ['Marcus', '[0]|[1]|s', '{{}}', '{{{}}', '%%']) {
+      should.equal(`Hallo ${name}`, mfTest.__mf('Hello {name}', { name }))
+    }
   })
 
   it('should work with plurals', () => {


### PR DESCRIPTION
The output from the `MessageFormat` compiled function may contain arbitrary user-provided content, and cannot safely be re-parsed as an interval string, Mustache template, or `printf` format string.

- Fixes #544.